### PR TITLE
Remove svelte a11y warnings during build step

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -308,8 +308,8 @@
 									<span>{ pack.count } stickers</span>
 								</div>
 								<div class="action">
-									<a class="button is-danger"
-										on:click="{ () => unsubscribeToPack(pack) }">Del</a>
+									<button class="button is-danger"
+										on:click="{ () => unsubscribeToPack(pack) }">Del</button>
 								</div>
 							</div>
 							{ /each }
@@ -332,11 +332,11 @@
 								</div>
 								<div class="action">
 									{ #if subscribedPacksSimple.includes(pack.id) }
-									<a class="button is-danger"
-										on:click="{ () => unsubscribeToPack(pack) }">Del</a>
+									<button class="button is-danger"
+										on:click="{ () => unsubscribeToPack(pack) }">Del</button>
 									{ :else }
-									<a class="button is-primary"
-										on:click="{ () => subscribeToPack(pack) }">Add</a>
+									<button class="button is-primary"
+										on:click="{ () => subscribeToPack(pack) }">Add</button>
 									{ /if }
 								</div>
 							</div>
@@ -762,7 +762,7 @@
 			}
 		}
 
-		a.button {
+		.button {
 			-moz-appearance: none;
 			-webkit-appearance: none;
 			align-items: center;
@@ -771,8 +771,6 @@
 			box-shadow: none;
 			display: inline-flex;
 			font-size: 1rem;
-			height: 1.5em;
-			line-height: 1.5;
 			padding-bottom: calc(0.375em - 1px);
 			padding-top: calc(0.375em - 1px);
 			position: relative;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -771,15 +771,12 @@
 			box-shadow: none;
 			display: inline-flex;
 			font-size: 1rem;
-			padding-bottom: calc(0.375em - 1px);
-			padding-top: calc(0.375em - 1px);
+			padding: calc(0.375em - 1px) 0.75em;
 			position: relative;
 			vertical-align: top;
 			user-select: none;
 			cursor: pointer;
 			justify-content: center;
-			padding-left: 0.75em;
-			padding-right: 0.75em;
 			text-align: center;
 			white-space: nowrap;
 			border-color: transparent;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -783,7 +783,7 @@
 			color: white;
 			background-color: #696080;
 
-			&.button.is-danger {
+			&.is-danger {
 				background-color: #883030;
 			}
 


### PR DESCRIPTION
This PR swaps the `<a>`s that were missing `href`s for `<button>`s in order to remove the a11y warnings when building. I also used CSS shorthand to combine the button padding styles and reduced specificity on the danger button selector