### PR TITLE
Merge pull request #16 from emyarod/affix-search-bar-position

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -571,15 +571,14 @@
 			}
 
 			.inputQuery {
-				width: calc(100% - 20px);
+				position: fixed;
+				z-index: 10;
+				width: 570px;
 				float: left;
-				display: -webkit-box;
-				display: -ms-flexbox;
 				display: flex;
 				height: 36px;
 				box-sizing: border-box;
-				margin-left: 15px;
-				margin-bottom: 10px;
+				margin: 0 15px 10px;
 				padding: 5px 12px;
 				border-radius: 3px;
 				border: 1px solid #151617;
@@ -652,6 +651,10 @@
 						margin-left: 20px;
 						margin-bottom: 10px;
 						height: 75px;
+
+						&:first-of-type {
+							margin-top: 46px;
+						}
 
 						div.handle,
 						div.preview,


### PR DESCRIPTION
This PR sets the search bar position to be fixed at the top of the sticker pack list. It also resolves a spacing issue where the right side of the search bar would overlap with the scroll bar

![2020-01-18_21-18-33](https://user-images.githubusercontent.com/8265238/72674072-29acee00-3a38-11ea-9239-a0cca991e765.gif)
