### PR TITLE
Merge pull request #17 from emyarod/keep-sticker-preview-aspect-ratio

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -226,9 +226,12 @@
 					<span id="pfavorites">Favorites</span>
 					{ #each favoriteStickers as sticker, i }
 					<div class="sticker">
-						<div class="image"
-							style="background-image: { `url(${baseURL}${sticker.pack}/${sticker.id.replace('.png', '_key.png')})` }"
-							on:click="{ () => sendSticker(sticker.pack, sticker.id) }"></div>
+						<img
+							class="image"
+							src="{`${baseURL}${sticker.pack}/${sticker.id.replace('.png', '_key.png')}`}"
+							alt="{sticker.pack}-{sticker.id}"
+							on:click="{ () => sendSticker(sticker.pack, sticker.id) }"
+						>
 						<div class="deleteFavorite"
 							on:click="{ () => unfavoriteSticker(sticker.pack, sticker.id) }">
 							<svg width="20" height="20" viewBox="0 0 24 24">
@@ -246,9 +249,12 @@
 
 					{ #each pack.files as sticker, i }
 					<div class="sticker">
-						<div class="image"
-							style="background-image: { `url(${baseURL}${pack.id}/${sticker.replace('.png', '_key.png')})` }"
-							on:click="{ () => sendSticker(pack.id, sticker) }"></div>
+						<img
+							class="image"
+							src="{`${baseURL}${pack.id}/${sticker.replace('.png', '_key.png')}`}"
+							alt="{pack.id}-{sticker}"
+							on:click="{ () => sendSticker(pack.id, sticker) }"
+						>
 						<div class="addFavorite"
 							on:click="{ () => favoriteSticker(pack.id, sticker) }">
 							<svg width="20" height="20" viewBox="0 0 24 24">
@@ -450,18 +456,16 @@
 					}
 
 					div.sticker {
+						display: flex;
+						align-items: center;
 						width: 100px;
 						height: 100px;
 						float: left;
 						position: relative;
 
-						div.image {
-							background-position: center;
-							background-size: cover;
-							background-repeat: no-repeat;
+						.image {
 							cursor: pointer;
 							width: 100px;
-							height: 100px;
 						}
 
 						div.addFavorite, div.deleteFavorite {


### PR DESCRIPTION
this PR swaps sticker preview `div`s (with CSS `background-image`) for `img` elements with unset height and fixed 100px width so that the full sticker is viewable in the preview

before:

![DiscordCanary_2020-01-18_22-01-08](https://user-images.githubusercontent.com/8265238/72674573-0d13b480-3a3e-11ea-8f20-bd52b2a753a8.png)

after:

![DiscordCanary_2020-01-18_21-52-17](https://user-images.githubusercontent.com/8265238/72674572-0d13b480-3a3e-11ea-8429-35c0f5b92db2.png)

the `position: relative` and `float: left` rules might be removable from the `div.sticker` class but I wanted to double check with you before deleting them