### PR TITLE
position Magane button with ResizeObserver

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -47,15 +47,17 @@
 	});
 
 	const keepMaganeInPlace = () => {
-		const el = document.querySelector(elementToCheck);
-		if (!el) {
-			if (showIcon) showIcon = false;
-			return;
-		}
-		if (!showIcon) showIcon = true;
-		const props = el.getBoundingClientRect();
-		coords.top = isThereTopBar ? props.top - 21 : props.top;
-		coords.left = props.left - 107;
+		setTimeout(() => {
+			const el = document.querySelector(elementToCheck);
+			if (!el) {
+				if (showIcon) showIcon = false;
+				return;
+			}
+			if (!showIcon) showIcon = true;
+			const props = el.getBoundingClientRect();
+			coords.top = isThereTopBar ? props.top - 21 : props.top;
+			coords.left = props.left - 107;
+		}, 0);
 	};
 
 	const waitForTextArea = () =>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,15 +60,17 @@
 		}, 0);
 	};
 
-	const waitForTextArea = () =>
-		new Promise(resolve => {
-			(function pollForTextArea() {
+	const waitForTextArea = () => {
+		let pollForTextArea;
+		return new Promise(resolve => {
+			(pollForTextArea = () => {
 				textArea = document.querySelector(selectorTextArea);
 				if (textArea) return resolve();
 				setTimeout(pollForTextArea, 500);
 			})();
 		});
-		
+	};
+
 	const positionMagane = entries => {
 		for (const entry of entries) {
 			if (entry.contentRect) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -76,9 +76,9 @@
 			if (entry.contentRect) {
 				keepMaganeInPlace();
 				if (!entry.contentRect.width && !entry.contentRect.height) {
-					resizeObserver.unobserve(textArea)
+					resizeObserver.unobserve(textArea); // eslint-disable-line no-use-before-define
 					waitForTextArea().then(() => {
-						resizeObserver.observe(textArea);
+						resizeObserver.observe(textArea); // eslint-disable-line no-use-before-define
 						keepMaganeInPlace();
 					});
 				}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -235,7 +235,7 @@
 			class:active="{ stickerWindowActive }"
 			on:click="{ () => toggleStickerWindow() }"
 			on:contextmenu|stopPropagation|preventDefault="{ () => grabPacks() }">
-			<div class="channel-textarea-stickers-content" />
+			<img class="channel-textarea-stickers-content" src="https://discordapp.com/assets/a42df564f00ed8bbca652dc9345d3834.svg" alt="Magane menu button">
 		</div>
 
 		{ #if stickerWindowActive }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -36,7 +36,7 @@ div#magane {
 			filter: grayscale(0%);
 		}
 	}
-	.channel-textarea-stickers-content {
+	img.channel-textarea-stickers-content {
 		width: 22px;
 		height: 22px;
 	}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -26,6 +26,7 @@ div#magane {
 
 	div.channel-textarea-stickers {
 		display: flex;
+		align-items: center;
 		cursor: pointer;
 		filter: grayscale(100%);
 		transition: all 0.2s ease;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -25,13 +25,7 @@ div#magane {
 	}
 
 	div.channel-textarea-stickers {
-		position: relative;
-		width: auto;
-		padding: 6px;
-		align-items: center;
 		display: flex;
-		justify-content: center;
-		max-height: 50px;
 		cursor: pointer;
 		filter: grayscale(100%);
 		transition: all 0.2s ease;
@@ -41,9 +35,7 @@ div#magane {
 			filter: grayscale(0%);
 		}
 	}
-	div.channel-textarea-stickers-content {
-		background-image: url('https://discordapp.com/assets/a42df564f00ed8bbca652dc9345d3834.svg');
-		background-size: 100%;
+	.channel-textarea-stickers-content {
 		width: 22px;
 		height: 22px;
 	}


### PR DESCRIPTION
Closes #18

~~this PR moves the DOM polling function to maintain the menu position from the `App.svelte` to `main.js`. instead of attaching the Magane container to the Discord base container, we search for the Discord button container and prepend Magane to that in order to avoid having to calculate positioning and possible overlap with textarea content~~

this PR adds a ResizeObserver on the message textarea to determine where to position the Magane menu button. This removes the need for a recurring 500ms `keepMaganeInPlace` function call, which also greatly reduces the number of updates Svelte needs to schedule. Now we only poll for the textarea element when it's missing from the DOM