### PR TITLE
re-added simplebar, fixed bdapi detection, ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
+    "@woden/svelte-simplebar": "^1.0.0",
     "eslint": "^6.8.0",
     "eslint-config-aqua": "^7.2.0",
     "eslint-plugin-svelte3": "^2.7.3",
@@ -32,7 +33,6 @@
     "rollup-plugin-serve": "^1.0.4",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",
-    "simplebar": "^5.1.0",
     "svelte": "^3.0.0",
     "svelte-preprocess": "^3.3.0",
     "svelte-scrollto": "^0.2.0"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,7 +4,6 @@
 	// Let's make the scrollbars pretty
 	import SimpleBar from '@woden/svelte-simplebar';
 	import * as animateScroll from 'svelte-scrollto';
-	import * as eases from 'svelte/easing';
 	import './styles/global.css';
 	import './styles/main.scss';
 
@@ -600,9 +599,7 @@
 	const scrollToStickers = id => {
 		animateScroll.scrollTo({
 			element: id,
-			container: document.querySelector('#magane .stickers .simplebar-content-wrapper'),
-			delay: 250,
-			easing: eases.cubicOut
+			container: document.querySelector('#magane .stickers .simplebar-content-wrapper')
 		});
 	};
 </script>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,18 +1,12 @@
 <script>
-	import { onMount, afterUpdate } from 'svelte';
+	import { onMount /* , afterUpdate */ } from 'svelte';
 
 	// Let's make the scrollbars pretty
-	// FIXME: Bugged with dynamically modified lists
-	// import SimpleBar from 'simplebar';
+	import SimpleBar from '@woden/svelte-simplebar';
 	import * as animateScroll from 'svelte-scrollto';
 	import * as eases from 'svelte/easing';
 	import './styles/global.css';
 	import './styles/main.scss';
-
-	animateScroll.setGlobalOptions({
-		delay: 250,
-		easing: eases.cubicOut
-	});
 
 	// APIs
 	window.magane = {};
@@ -39,20 +33,14 @@
 	let onCooldown = false;
 	let storage = null;
 	let packsSearch = null;
-	let stickerContainer = null;
 	let resizeObserver;
-
-	/* eslint-disable no-unused-vars */
-	let mainScrollBar;
-	let packsScrollBar;
-	/* eslint-enable no-unused-vars */
 
 	const log = (message, type = 'log') =>
 		console[type]('%c[Magane]%c', 'color: #3a71c1; font-weight: 700', '', message);
 
 	const toast = (message, options) => {
 		/* global BdApi */
-		if (BdApi && typeof BdApi.showToast === 'function') {
+		if (typeof BdApi === 'object' && typeof BdApi.showToast === 'function') {
 			return BdApi.showToast(message, options);
 		}
 
@@ -85,24 +73,12 @@
 		return toast(message, options);
 	};
 
+	/*
 	afterUpdate(() => {
 		// Only do stuff if the Magane window is open
-		// eslint-disable-next-line no-useless-return
 		if (!stickerWindowActive) return;
-
-		/*
-		// FIXME: Bugged with dynamically modified lists
-		if (!mainScrollBar) {
-			const exists = document.getElementById('stickers');
-			if (exists) mainScrollBar = new SimpleBar(exists);
-		}
-
-		if (!packsScrollBar) {
-			const exists = document.getElementById('packsBar');
-			if (exists) packsScrollBar = new SimpleBar(exists);
-		}
-		*/
 	});
+	*/
 
 	const keepMaganeInPlace = () => {
 		setTimeout(() => {
@@ -331,7 +307,7 @@
 		// stickerWindowActive = false;
 
 		try {
-			toast('Sending sticker\u2026');
+			toast('Sending\u2026');
 			const channel = window.location.href.split('/').slice(-1)[0];
 
 			const url = formatUrl(pack, id);
@@ -352,7 +328,7 @@
 			const formData = new FormData();
 			formData.append('file', myBlob, filename);
 
-			log(`Sending sticker\u2026`);
+			log(`Sending\u2026`);
 			token = token.replace(/"/ig, '');
 			token = token.replace(/^Bot\s*/i, '');
 			await fetch(`https://discordapp.com/api/channels/${channel}/messages`, {
@@ -360,7 +336,7 @@
 				method: 'POST',
 				body: formData
 			});
-			toastSuccess('Sticker sent!');
+			toastSuccess('Sent!');
 		} catch (error) {
 			console.error(error);
 			toastError('Unexpected error occurred when sending sticker. Check your console for details.');
@@ -372,7 +348,7 @@
 	const favoriteSticker = (pack, id) => {
 		for (const favorite of favoriteStickers) {
 			if (favorite.id === id) {
-				return toastError('You already have this sticker in your favorites.');
+				return toastError('This sticker is already in your favorites.');
 			}
 		}
 
@@ -387,7 +363,7 @@
 		favoriteStickers = [...favoriteStickers, favorite];
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Favorited sticker > ${id} of pack ${pack}`);
-		toastSuccess('Added sticker to favorites.', { nolog: true });
+		toastSuccess('Favorited!', { nolog: true });
 	};
 
 	const unfavoriteSticker = (pack, id) => {
@@ -411,7 +387,7 @@
 
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Unfavorited sticker > ${id} of pack ${pack}`);
-		toastInfo('Unfavorited sticker.', { nolog: true });
+		toastInfo('Unfavorited!', { nolog: true });
 	};
 
 	const filterPacks = () => {
@@ -574,11 +550,10 @@
 	onMount(async () => {
 		try {
 			log('Mounted on DOM');
-			toastInfo('Initializing Magane\u2026');
 			getLocalStorage();
 			await checkAuth();
 			await grabPacks();
-			toastSuccess('Magane initialized. You can start sending stickers now!');
+			toastSuccess('Magane initialized!');
 			resizeObserver = new ResizeObserver(positionMagane);
 			await waitForTextArea();
 			resizeObserver.observe(textArea);
@@ -606,7 +581,6 @@
 	};
 
 	const toggleStickerWindow = () => {
-		mainScrollBar = null;
 		stickerWindowActive = !stickerWindowActive;
 		if (stickerWindowActive) {
 			document.addEventListener('click', maganeBlurHandler);
@@ -616,14 +590,20 @@
 	};
 
 	const toggleStickerModal = () => {
-		mainScrollBar = null;
-		packsScrollBar = null;
 		isStickerAddModalActive = !isStickerAddModalActive;
 	};
 
 	const activateTab = value => {
-		packsScrollBar = null;
 		activeTab = value;
+	};
+
+	const scrollToStickers = id => {
+		animateScroll.scrollTo({
+			element: id,
+			container: document.querySelector('#magane .stickers .simplebar-content-wrapper'),
+			delay: 250,
+			easing: eases.cubicOut
+		});
 	};
 </script>
 
@@ -639,9 +619,7 @@
 
 		{ #if stickerWindowActive }
 		<div class="stickerWindow">
-			<div id="stickers"
-				class="stickers"
-				bind:this={ stickerContainer }>
+			<SimpleBar class="stickers" style="">
 				{ #if !favoriteStickers && !subscribedPacks }
 				<h3 class="getStarted">It seems you aren't subscribed to any pack yet. Click the plus symbol on the bottom-left to get started! 🎉</h3>
 				{ /if }
@@ -692,34 +670,30 @@
 					{ /each }
 				</div>
 				{ /each }
-			</div>
+			</SimpleBar>
 
-			<div class="packs">
-				<div class="pack"
-					on:click="{ () => toggleStickerModal() }"
-					title="Manage subscribed packs" >
-					<div class="icon-plus" />
+			<SimpleBar class="packs" style="">
+				<div class="packs-wrapper">
+					<div class="pack"
+						on:click="{ () => toggleStickerModal() }"
+						title="Manage subscribed packs" >
+						<div class="icon-plus" />
+					</div>
+					{ #if favoriteSticker && favoriteSticker.length }
+					<div class="pack"
+						on:click={ () => scrollToStickers('#pfavorites') }
+						title="Favorites" >
+						<div class="icon-favorite" />
+					</div>
+					{ /if }
+					{ #each subscribedPacks as pack, i }
+					<div class="pack"
+						on:click={ () => scrollToStickers(`#p${pack.id}`) }
+						title="{ pack.name }"
+						style="background-image: { `url(${formatUrl(pack.id, pack.files[0])})` }" />
+					{ /each }
 				</div>
-				{ #if favoriteSticker && favoriteSticker.length }
-				<div class="pack"
-					on:click={ () => animateScroll.scrollTo({
-						element: '#pfavorites',
-						container: stickerContainer
-					}) }
-					title="Favorites" >
-					<div class="icon-favorite" />
-				</div>
-				{ /if }
-				{ #each subscribedPacks as pack, i }
-				<div class="pack"
-					on:click={ () => animateScroll.scrollTo({
-						element: `#p${pack.id}`,
-						container: stickerContainer
-					}) }
-					title="{ pack.name }"
-					style="background-image: { `url(${formatUrl(pack.id, pack.files[0])})` }" />
-				{ /each }
-			</div>
+			</SimpleBar>
 
 			<!-- Sticker add modal -->
 			{ #if isStickerAddModalActive }
@@ -743,8 +717,7 @@
 						</div>
 
 						{ #if activeTab === 0 }
-						<div class="tabContent"
-							id="packsBar">
+						<SimpleBar class="tabContent" style="">
 							{ #each subscribedPacks as pack }
 							<div class="pack">
 								<div class="preview"
@@ -759,7 +732,7 @@
 								</div>
 							</div>
 							{ /each }
-						</div>
+						</SimpleBar>
 						{ :else if activeTab === 1 }
 						<input
 							on:keyup="{ filterPacks }"
@@ -767,8 +740,7 @@
 							class="inputQuery"
 							type="text"
 							placeholder="Search" />
-						<div class="tabContent"
-							id="packsBar">
+						<SimpleBar class="tabContent" style="">
 							{ #each filteredPacks as pack }
 							<div class="pack">
 								<div class="preview"
@@ -788,7 +760,7 @@
 								</div>
 							</div>
 							{ /each }
-						</div>
+						</SimpleBar>
 						{ /if }
 					</div>
 				</div>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -153,24 +153,20 @@ div#magane {
 			position: absolute;
 			bottom: 0;
 			width: 100%;
-			height: auto; /* accommodate scrollbar when required */
+			height: 50px;
 			background: $backgroundSecondary;
-			display: flex;
-			flex-direction: row;
-			overflow: auto hidden;
+			overflow: auto;
 
-			/* hacky countermeasure due to margin collapse */
-			&::before,
-			&::after {
-				content: '';
-				padding-left: 5px;
+			div.packs-wrapper {
+				white-space: nowrap;
+				float: left;
+				width: 100%;
 			}
 
 			div.pack {
-				flex: 0 0 auto;
+				display: inline-block;
 				height: 40px;
 				width: 40px;
-				float: left;
 				margin: 5px;
 				cursor: pointer;
 				background-position: center;
@@ -178,14 +174,6 @@ div#magane {
 				background-repeat: no-repeat;
 				transition: all 0.2s ease;
 				filter: grayscale(100%);
-
-				&:first-of-type {
-					margin-left: 0;
-				}
-
-				&:last-of-type {
-					margin-right: 0;
-				}
 
 				&:hover,
 				div.pack.active {
@@ -307,10 +295,12 @@ div#magane {
 
 				div.pack {
 					height: 75px;
-					width: calc(100% - 20px);
+					width: 600px; /* if not static, its width may flicker due to simplebar */
 					float: left;
 					display: flex;
-					margin: 5px 0 5px 20px;
+					padding: 0 20px;
+					box-sizing: border-box;
+					margin-bottom: 5px;
 
 					&:last-of-type {
 						margin-bottom: 0;
@@ -319,7 +309,7 @@ div#magane {
 					div.handle,
 					div.preview,
 					div.action {
-						flex: none;
+						flex: 0 0 auto;
 						width: 75px;
 						height: 75px;
 					}
@@ -346,11 +336,11 @@ div#magane {
 
 					div.action {
 						padding-top: 20px;
-						padding-left: 10px;
+						text-align: right;
 					}
 
 					div.info {
-						flex: 1;
+						flex: 1 1 auto;
 						padding: 14px;
 
 						> span {

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,13 @@
   dependencies:
     "@types/node" "*"
 
+"@woden/svelte-simplebar@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@woden/svelte-simplebar/-/svelte-simplebar-1.0.0.tgz#05df3326cc30b96e9cda2d5943b5e94ed97db4e7"
+  integrity sha512-YYr5JhmqNnNpk2E0Uf1nE8ObUmR072b175s1A3G5WTmeiyLfKbhmTYx2vfZh4vrljDtuWt1f+79e/s6ybrS4Eg==
+  dependencies:
+    simplebar "^5.1.0"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
simplified toast messages,
simplebar also works in packs bottom toolbar

replaced main simplebar dependency with `@woden/svelte-simplebar`

---

fixed bdapi detection: in browser env, doing `!var` to detect undefined var would throw. i forgot, luls
`@woden/svelte-simplebar`: https://www.npmjs.com/package/@woden/svelte-simplebar, can confirm this works even when the content gets dynamically updated (i.e. searching packs). it looks a lot better with packs bottom toolbar as well

---

you'll be seeing some lines like these:
```js
<SimpleBar class="tabContent" style="">
```
the empty `style=""` tag is necessary cause the module would otherwise throw warnings (not errors). i suppose the dev's intention was so that people would not forget to specify the container's dimension (width/height), however it'd still work just fine when the dimension is specified on css files. so it's basically just there to suppress the warnings