### PR TITLE
use images.weserv.nl for consistency, line emojis support, and more

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -941,6 +941,10 @@
 									<button class="button is-primary"
 										on:click="{ () => subscribeToPack(pack) }">Add</button>
 									{ /if }
+									{ #if localPacks[pack.id] }
+									<button class="button deletePack"
+										on:click="{ () => window.magane.deletePack(pack.id) }">X</button>
+									{ /if }
 								</div>
 							</div>
 							{ /each }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -759,7 +759,11 @@
 	const parseLinePack = async () => {
 		if (!linePackSearch) return;
 		try {
-			const id = linePackSearch.match(/\d+/)[0];
+			const match = linePackSearch.match(/^(https?:\/\/store\.line\.me\/stickershop\/product\/)?(\d+)/);
+			const id = Number(match[2]);
+			if (!match || isNaN(id) || !isFinite(id) || id < 0) {
+				return toastError('Unsupported LINE Store URL or ID.');
+			}
 			const response = await fetch(`https://magane.moe/api/proxy/${id}`);
 			const props = await response.json();
 			linePackSearch = null;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -242,7 +242,7 @@
 	};
 
 	const subscribeToPack = pack => {
-		if (subscribedPacks.includes(pack)) return;
+		if (subscribedPacks.findIndex(p => p.id === pack.id) !== -1) return;
 		subscribedPacks = [...subscribedPacks, pack];
 		subscribedPacksSimple = [...subscribedPacksSimple, pack.id];
 
@@ -251,8 +251,6 @@
 	};
 
 	const unsubscribeToPack = pack => {
-		if (!subscribedPacks.includes(pack)) return;
-
 		for (let i = 0; i < subscribedPacks.length; i++) {
 			if (subscribedPacks[i].id === pack.id) {
 				subscribedPacks.splice(i, 1);
@@ -263,10 +261,10 @@
 				subscribedPacksSimple = subscribedPacksSimple;
 
 				log(`Unsubscribed from pack > ${pack.name}`);
+				saveToLocalStorage('magane.subscribed', subscribedPacks);
+				return;
 			}
 		}
-
-		saveToLocalStorage('magane.subscribed', subscribedPacks);
 	};
 
 	const formatUrl = (pack, id, sending) => {
@@ -727,10 +725,11 @@
 		const value = event.target.value.trim();
 		if (event.keyCode !== 13 || !value.length) return;
 
-		const newIndex = Number(value);
-		if (isNaN(newIndex) || newIndex < 0 || newIndex > subscribedPacks.length - 1) {
-			return toastError(`New index must be ≥ 0 and ≤ ${subscribedPacks.length - 1}!`);
+		let newIndex = Number(value);
+		if (isNaN(newIndex) || newIndex < 1 || newIndex > subscribedPacks.length) {
+			return toastError(`New position must be ≥ 1 and ≤ ${subscribedPacks.length}!`);
 		}
+		newIndex--;
 
 		const packId = event.target.dataset.pack;
 		if (typeof packId === 'undefined') return;
@@ -754,7 +753,7 @@
 		subscribedPacks = subscribedPacks;
 		subscribedPacksSimple = subscribedPacksSimple;
 		saveToLocalStorage('magane.subscribed', subscribedPacks);
-		toastSuccess(`Moved pack from index ${oldIndex} to ${newIndex}!`);
+		toastSuccess(`Moved pack from position ${oldIndex + 1} to ${newIndex + 1}!`);
 	};
 
 	const parseLinePack = async () => {
@@ -888,7 +887,7 @@
 
 						{ #if activeTab === 0 }
 						<SimpleBar class="tabContent" style="">
-							{ #each subscribedPacks as pack, index }
+							{ #each subscribedPacks as pack, i (pack.id) }
 							<div class="pack">
 								{ #if subscribedPacks.length > 1 }
 								<div class="index">
@@ -898,7 +897,7 @@
 										class="inputPackIndex"
 										type="text"
 										data-pack={ pack.id }
-										value={ index } />
+										value={ i + 1 } />
 								</div>
 								{ /if }
 								<div class="preview"

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -339,8 +339,27 @@ div#magane {
 					div.preview,
 					div.action {
 						flex: 0 0 auto;
-						width: 75px;
+						min-width: 75px;
 						height: 75px;
+
+						button.deletePack {
+							width: 31px;
+							color: transparent;
+
+							&::before {
+								background-image: url('/assets/9b1b76abb59b5c8a41daea1342f2138a.svg');
+								background-size: 75%;
+								background-repeat: no-repeat;
+								background-position: center;
+								filter: grayscale(100%) invert(1) brightness(1.25);
+								content: "";
+								position: absolute;
+								top: 0;
+								left: 0;
+								width: 100%;
+								height: 100%;
+							}
+						}
 					}
 
 					div.index {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -349,7 +349,7 @@ div#magane {
 
 					div.preview {
 						background-position: center;
-						background-size: cover;
+						background-size: contain;
 						background-repeat: no-repeat;
 					}
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -96,6 +96,7 @@ div#magane {
 				div.sticker {
 					display: flex;
 					align-items: center;
+					justify-content: center;
 					width: 100px;
 					height: 100px;
 					float: left;
@@ -103,7 +104,8 @@ div#magane {
 
 					.image {
 						cursor: pointer;
-						width: 100px;
+						max-height: 100%;
+						max-width: 100%;
 					}
 
 					div.addFavorite, div.deleteFavorite {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -343,21 +343,29 @@ div#magane {
 						height: 75px;
 
 						button.deletePack {
-							width: 31px;
-							color: transparent;
+							width: 36px;
+							height: 36px;
 
-							&::before {
-								background-image: url('/assets/9b1b76abb59b5c8a41daea1342f2138a.svg');
-								background-size: 75%;
-								background-repeat: no-repeat;
-								background-position: center;
-								filter: grayscale(100%) invert(1) brightness(1.25);
+							&:before,
+							&:after {
+								background-color: $textColor;
 								content: "";
+								display: block;
+								left: 50%;
 								position: absolute;
-								top: 0;
-								left: 0;
-								width: 100%;
-								height: 100%;
+								top: 50%;
+								transform: translateX(-50%) translateY(-50%) rotate(45deg);
+								transform-origin: center center;
+							}
+
+							&:before {
+								height: 2px;
+								width: 50%;
+							}
+
+							&:after {
+								height: 50%;
+								width: 2px;
 							}
 						}
 					}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -316,6 +316,7 @@ div#magane {
 							padding: 2rem;
 							padding-top: 0;
 							margin-top: -5rem;
+							user-select: text;
 						}
 					}
 				}


### PR DESCRIPTION
- images.weserv.nl for downsizing line stickers to 180p and 100p on the fly (consistency with magane packs)
- line emojis support with `magane.appendEmojisPack(title, packId, count)` - *btw they end up being as big as stickers, lmao*
- fixed 100p variants of magane packs not being used for UI
- and some other smaller tweaks (pls check commit messages)

😘

![Screenshot](https://i.fiery.me/cFNBU.png)
*ids for line emojis are like hella long - dont mind the aesthetic differences, im using a theme*

![Screenshot](https://i.fiery.me/dlwfL.png)
*userscript pog*

for line emojis, their internals are slightly different to stickers, so i couldnt really re-use `magane.appendPack()` (e.g. adding a true/false toggle for emojis or smth)
for starters, individual emojis are simply stored as 001, 002, ... N
basically unlike stickers, they're on their individual paths/directories mapped by their pack ids