### PR TITLE
Implement replace and export database

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@
 
 name: Release
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
@@ -23,12 +23,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
         uses: actions/checkout@v2
-      
+
       - name: Install Node v14
         uses: actions/setup-node@v1
         with:
           node-version: 14
-          
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -49,4 +49,4 @@ jobs:
       - uses: EndBug/add-and-commit@v6
         with:
           branch: master
-          message: 'Deploy new dist file'
+          message: 'dist: deploy new dist file'

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1064,7 +1064,7 @@
 						</SimpleBar>
 						{ :else if activeTab === 2 }
 						<div class="tabContent line-proxy">
-							<p>If you are looking for a sticker pack that is not provided by magane, you can go to the LINE store and pick whatever pack you want and paste the full URL in the box below. <br><br>For example: https://store.line.me/stickershop/product/17573/ja</p>
+							<p>If you are looking for a sticker pack that is not provided by Magane, you can go to the LINE Store and pick whatever pack you want and paste the full URL in the box below. <br><br>For example: https://store.line.me/stickershop/product/17573/ja</p>
 							<input
 								bind:value={ linePackSearch }
 								class="inputQuery"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -412,7 +412,7 @@
 		favoriteStickers = [...favoriteStickers, favorite];
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Favorited sticker > ${id} of pack ${pack}`);
-		toastSuccess('Favorited', { nolog: true });
+		toastSuccess('Favorited.', { nolog: true });
 	};
 
 	const unfavoriteSticker = (pack, id) => {
@@ -436,7 +436,7 @@
 
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Unfavorited sticker > ${id} of pack ${pack}`);
-		toastInfo('Unfavorited', { nolog: true });
+		toastInfo('Unfavorited.', { nolog: true });
 	};
 
 	const filterPacks = () => {
@@ -543,7 +543,7 @@
 			storage.setItem('magane.favorites', JSON.stringify(favorites));
 			storage.setItem('magane.subscribed', JSON.stringify(subscribed));
 			await grabPacks();
-			toastSuccess('Migration successful');
+			toastSuccess('Migration successful.');
 		}
 	};
 
@@ -823,7 +823,7 @@
 
 		let newIndex = Number(value);
 		if (isNaN(newIndex) || newIndex < 1 || newIndex > subscribedPacks.length) {
-			return toastError(`New position must be ≥ 1 and ≤ ${subscribedPacks.length}!`);
+			return toastError(`New position must be ≥ 1 and ≤ ${subscribedPacks.length}.`);
 		}
 		newIndex--;
 
@@ -850,7 +850,7 @@
 		subscribedPacks = subscribedPacks;
 		subscribedPacksSimple = subscribedPacksSimple;
 		saveToLocalStorage('magane.subscribed', subscribedPacks);
-		toastSuccess(`Moved pack from position ${oldIndex + 1} to ${newIndex + 1}!`);
+		toastSuccess(`Moved pack from position ${oldIndex + 1} to ${newIndex + 1}.`);
 	};
 
 	const parseLinePack = async () => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1178,8 +1178,8 @@
 								<p>
 									<input
 										id="replaceDatabaseInput"
-										class="visually-hidden"
 										type="file"
+										style="display: none"
 										accept="application/JSON"
 										on:click="{ event => event.stopPropagation() }"
 										on:change="{ onReplaceDatabaseChange }" />

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -327,6 +327,18 @@ div#magane {
 							user-select: text;
 						}
 					}
+
+					&.misc {
+						margin: 0 5px 10px;
+
+						.section {
+							padding: 5px 12px;
+
+							.section-title {
+								font-weight: 800;
+							}
+						}
+					}
 				}
 
 				div.pack {
@@ -527,6 +539,10 @@ div#magane {
 
 		&:hover, &.is-primary:hover {
 			transform: scale3d(1.1, 1.1, 1.1);
+		}
+
+		&.has-width-full {
+			width: 100%;
 		}
 	}
 }


### PR DESCRIPTION
![ShareX_Discord_20220410-121639](https://user-images.githubusercontent.com/9364930/162605308-77b23eaa-874c-479f-8e29-6a4702754328.png)
![ShareX_Discord_20220410-121649](https://user-images.githubusercontent.com/9364930/162605309-b683ba36-abbd-4926-b27d-6b45f7de7fa4.png)

In addition, the Misc tab can probably be used for some basic settings in the future ~~(assuming we don't have Magane integrated into Discord's emojis menu yet)~~

Not using BetterDiscord's built-in plugin settings due to complexity with current implementation

The first 4 micro commits are unrelated to the new feature, but I think they're good to be merged, and seemed small enough not to warrant their own PRs