### PR TITLE
feat: settings for you, settings for me, settings for everybody AND performance!

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '14'
-		  cache: 'yarn'
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,23 +22,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node v14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
+          node-version: '14'
+		  cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "dev": "rollup -c -w"
   },
   "devDependencies": {
+    "@jbfulgencio/svelte-simplebar": "^1.0.0",
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^6.0.0",
-    "@woden/svelte-simplebar": "^1.0.0",
     "eslint": "^6.8.0",
     "eslint-config-aqua": "^7.2.0",
     "eslint-plugin-svelte3": "^2.7.3",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -106,7 +106,7 @@
 			if (!showIcon) showIcon = true;
 			const props = el.getBoundingClientRect();
 			coords.top = (isThereTopBar ? props.top - 21 : props.top) + 1;
-			coords.left = props.left - 100;
+			coords.left = props.left - 108;
 		}, 0);
 	};
 
@@ -761,8 +761,9 @@
 		const stickerWindow = document.querySelector('#magane .stickerWindow');
 		if (stickerWindow) {
 			const { x, y, width, height } = stickerWindow.getBoundingClientRect();
+			const maganeButton = document.querySelector('#magane .magane-button');
 			if (
-				!document.querySelector('#magane img').isSameNode(e.target) &&
+				!(e.target === maganeButton || e.target.parentNode === maganeButton) &&
 				!((e.clientX <= x + width && e.clientX >= x) &&
 				(e.clientY <= y + height && e.clientY >= y))
 			) {
@@ -1073,7 +1074,7 @@
 <main>
 	<div id="magane"
 		style="top: { `${coords.top}px` }; left: { `${coords.left}px` }; display: { showIcon ? 'flex' : 'none' };">
-		<div class="channel-textarea-emoji channel-textarea-stickers"
+		<div class="magane-button channel-textarea-emoji channel-textarea-stickers"
 			class:active="{ stickerWindowActive }"
 			on:click="{ () => toggleStickerWindow() }"
 			on:contextmenu|stopPropagation|preventDefault="{ () => grabPacks() }">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -467,7 +467,7 @@
 		favoriteStickers = [...favoriteStickers, favorite];
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Favorited sticker > ${id} of pack ${pack}`);
-		toastSuccess('Favorited.', { nolog: true });
+		toastSuccess('Favorited!', { nolog: true });
 	};
 
 	const unfavoriteSticker = (pack, id) => {
@@ -491,7 +491,7 @@
 
 		saveToLocalStorage('magane.favorites', favoriteStickers);
 		log(`Unfavorited sticker > ${id} of pack ${pack}`);
-		toastInfo('Unfavorited.', { nolog: true });
+		toastInfo('Unfavorited!', { nolog: true });
 	};
 
 	const filterPacks = () => {
@@ -954,7 +954,7 @@
 		log(`settings['${name}'] = ${settings[name]}`);
 
 		saveToLocalStorage('magane.settings', settings);
-		toastSuccess('Settings saved.', { nolog: true });
+		toastSuccess('Settings saved!', { nolog: true });
 	};
 
 	const onReplaceDatabaseChange = event => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -49,7 +49,8 @@
 	let resizeObserver;
 
 	const settings = {
-		closeWindowOnSend: false
+		closeWindowOnSend: false,
+		disableDownscale: false
 	};
 
 	// NOTE: For the time being only used to limit keys in replace/export database functions
@@ -307,7 +308,9 @@
 				// In case one day images.weserv.nl starts properly supporting APNGs -> GIFs
 				append += '&output=gif';
 			}
-			url = `https://images.weserv.nl/?url=${encodeURIComponent(url)}${append}`;
+			if (!settings.disableDownscale) {
+				url = `https://images.weserv.nl/?url=${encodeURIComponent(url)}${append}`;
+			}
 		} else if (pack.startsWith('emojis-')) {
 			// LINE Store emojis
 			// 220p: https://stickershop.line-scdn.net/sticonshop/v1/sticon/%pack%/iPhone/%id%.png
@@ -319,7 +322,9 @@
 			const template = 'https://stickershop.line-scdn.net/sticonshop/v1/sticon/%pack%/android/%id%.png';
 			url = template.replace(/%pack%/g, pack.split('-')[1]).replace(/%id%/g, id.split('.')[0]);
 			const append = sending ? '' : '&h=100p';
-			url = `https://images.weserv.nl/?url=${encodeURIComponent(url)}${append}`;
+			if (!settings.disableDownscale) {
+				url = `https://images.weserv.nl/?url=${encodeURIComponent(url)}${append}`;
+			}
 		} else if (pack.startsWith('custom-')) {
 			// Custom packs
 			const template = localPacks[pack].template;
@@ -1265,6 +1270,13 @@
 										type="checkbox"
 										bind:checked={ settings.closeWindowOnSend } />
 									<label for="closeWindowOnSend">Close window when sending a sticker</label>
+								</p>
+								<p>
+									<input
+										name="disableDownscale"
+										type="checkbox"
+										bind:checked={ settings.disableDownscale } />
+									<label for="disableDownscale">Disable downscaling of manually imported LINE Store packs</label>
 								</p>
 							</div>
 							<div class="section database">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1268,25 +1268,31 @@
 							<div class="section settings" on:change="{ onSettingsChange }">
 								<p class="section-title">Settings</p>
 								<p>
-									<input
-										name="disableToasts"
-										type="checkbox"
-										bind:checked={ settings.disableToasts } />
-									<label for="disableToasts">Disable Toasts</label>
+									<label>
+										<input
+											name="disableToasts"
+											type="checkbox"
+											bind:checked={ settings.disableToasts } />
+										Disable Toasts
+									</label>
 								</p>
 								<p>
-									<input
-										name="closeWindowOnSend"
-										type="checkbox"
-										bind:checked={ settings.closeWindowOnSend } />
-									<label for="closeWindowOnSend">Close window when sending a sticker</label>
+									<label>
+										<input
+											name="closeWindowOnSend"
+											type="checkbox"
+											bind:checked={ settings.closeWindowOnSend } />
+										Close window when sending a sticker
+									</label>
 								</p>
 								<p>
-									<input
-										name="disableDownscale"
-										type="checkbox"
-										bind:checked={ settings.disableDownscale } />
-									<label for="disableDownscale">Disable downscaling of manually imported LINE Store packs</label>
+									<label>
+										<input
+											name="disableDownscale"
+											type="checkbox"
+											bind:checked={ settings.disableDownscale } />
+										Disable downscaling of manually imported LINE Store packs
+									</label>
 								</p>
 							</div>
 							<div class="section database">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,7 +3,7 @@
 	import { onMount, afterUpdate } from 'svelte';
 
 	// Let's make the scrollbars pretty
-	import SimpleBar from '@woden/svelte-simplebar';
+	import SimpleBar from '@jbfulgencio/svelte-simplebar';
 	import * as animateScroll from 'svelte-scrollto';
 	import './styles/global.css';
 	import './styles/main.scss';

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -307,6 +307,7 @@
 	const getTextAreaInstance = () => {
 		let cursor = textArea[Object.keys(textArea).find(key =>
 			key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber'))];
+		if (!cursor) return null;
 		while (
 			!(
 				cursor.stateNode &&

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,8 @@
 	const settings = {
 		disableToasts: false,
 		closeWindowOnSend: false,
-		disableDownscale: false
+		disableDownscale: false,
+		useLeftToolbar: false
 	};
 
 	// NOTE: For the time being only used to limit keys in replace/export database functions
@@ -1007,7 +1008,7 @@
 		</div>
 
 		<div class="stickerWindow" style="{ stickerWindowActive ? '' : 'display: none;' }">
-			<SimpleBar class="stickers" style="">
+			<SimpleBar class="stickers { settings.useLeftToolbar ? 'has-left-toolbar' : '' }" style="">
 				{ #if !favoriteStickers && !subscribedPacks }
 				<h3 class="getStarted">It seems you aren't subscribed to any pack yet. Click the plus symbol on the bottom-left to get started! 🎉</h3>
 				{ /if }
@@ -1070,7 +1071,7 @@
 				{ /each }
 			</SimpleBar>
 
-			<div class="bottom-toolbar">
+			<div class="packs-toolbar { settings.useLeftToolbar ? 'left-toolbar' : 'bottom-toolbar' }">
 				<div class="packs packs-controls">
 					<div class="packs-wrapper">
 						<div class="pack"
@@ -1232,6 +1233,15 @@
 											type="checkbox"
 											bind:checked={ settings.closeWindowOnSend } />
 										Close window when sending a sticker
+									</label>
+								</p>
+								<p>
+									<label>
+										<input
+											name="useLeftToolbar"
+											type="checkbox"
+											bind:checked={ settings.useLeftToolbar } />
+										Use left toolbar instead of bottom toolbar on main window
 									</label>
 								</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
 	/* global BdApi */
-	import { onMount, afterUpdate } from 'svelte';
+	import { onMount } from 'svelte';
 
 	// Let's make the scrollbars pretty
 	import SimpleBar from '@jbfulgencio/svelte-simplebar';
@@ -15,8 +15,7 @@
 	const elementToCheck = '[class^=channelTextArea] [class^=buttons]';
 	const coords = { top: 0, left: 0 };
 	const selectorTextArea = '[class^=channelTextArea-]';
-	const selectorStickersContainer = '#magane .stickers .simplebar-content-wrapper';
-	const selectorStickerModalContent = '#magane .stickersModal .simplebar-content-wrapper';
+	const selectorStickerWindowScroller = '#magane .stickers .simplebar-content-wrapper';
 	let textArea = document.querySelector(selectorTextArea);
 	let showIcon = true;
 	let isThereTopBar = null;
@@ -35,15 +34,6 @@
 	const localPackIdRegex = /^(startswith|emojis|custom)-/;
 	const localPacks = {};
 	let linePackSearch = null;
-
-	const stickerWindowScrolls = [
-		{ selector: selectorStickersContainer, type: 'scrollTop', position: 0 },
-		{ selector: '#magane .packs .simplebar-content-wrapper', type: 'scrollLeft', position: 0 }
-	];
-	const stickerModalScrolls = [0, 0];
-	let doStickerWindowScrolls = false;
-	let doStickerModalScrolls = false;
-
 	let onCooldown = false;
 	let storage = null;
 	let packsSearch = null;
@@ -773,102 +763,37 @@
 		}
 	};
 
-	const restoreStickerWindowScrolls = () => {
-		for (let i = 0; i < stickerWindowScrolls.length; i++) {
-			const element = document.querySelector(stickerWindowScrolls[i].selector);
-			if (element) {
-				element[stickerWindowScrolls[i].type] = stickerWindowScrolls[i].position;
-			}
-		}
-	};
-
-	const storeStickerWindowScrolls = () => {
-		for (let i = 0; i < stickerWindowScrolls.length; i++) {
-			const element = document.querySelector(stickerWindowScrolls[i].selector);
-			if (element) {
-				stickerWindowScrolls[i].position = element[stickerWindowScrolls[i].type];
-			}
-		}
-	};
-
-	const restoreStickerModalScrolls = () => {
-		const element = document.querySelector(selectorStickerModalContent);
-		if (element) {
-			element.scrollTop = stickerModalScrolls[activeTab];
-		}
-	};
-
-	const storeStickerModalScrolls = () => {
-		const element = document.querySelector(selectorStickerModalContent);
-		if (element) {
-			stickerModalScrolls[activeTab] = element.scrollTop;
-		}
-	};
-
-	afterUpdate(() => {
-		// Only do stuff if the Magane window is open
-		if (!stickerWindowActive) return;
-
-		if (doStickerWindowScrolls) {
-			restoreStickerWindowScrolls();
-			doStickerWindowScrolls = false;
-		}
-
-		if (doStickerModalScrolls) {
-			restoreStickerModalScrolls();
-			doStickerModalScrolls = false;
-		}
-	});
-
 	const toggleStickerWindow = forceState => {
 		const active = typeof forceState === 'undefined' ? !stickerWindowActive : forceState;
 		if (active) {
 			document.addEventListener('click', maganeBlurHandler);
-			doStickerWindowScrolls = true;
-			if (stickerAddModalActive) {
-				doStickerModalScrolls = true;
-			}
 		} else {
 			document.removeEventListener('click', maganeBlurHandler);
-			storeStickerWindowScrolls();
-			if (stickerAddModalActive) {
-				storeStickerModalScrolls();
-			}
 		}
 		stickerWindowActive = active;
 	};
 
 	const toggleStickerModal = () => {
 		const active = !stickerAddModalActive;
-		if (active) {
-			if (activeTab === null) {
-				// eslint-disable-next-line no-use-before-define
-				activateTab(0);
-			} else {
-				doStickerModalScrolls = true;
-			}
-		} else {
-			storeStickerModalScrolls();
+		if (active && activeTab === null) {
+			// eslint-disable-next-line no-use-before-define
+			activateTab(0);
 		}
 		stickerAddModalActive = active;
 	};
 
 	const activateTab = value => {
-		if (activeTab !== null) {
-			storeStickerModalScrolls();
-		}
 		activeTab = value;
 		if (!stickerAddModalTabsInit[activeTab]) {
 			// Trigger DOM build for this tab for the first time (if applicable)
 			stickerAddModalTabsInit[activeTab] = true;
 		}
-		doStickerModalScrolls = true;
 	};
 
 	const scrollToStickers = id => {
 		animateScroll.scrollTo({
 			element: id,
-			container: document.querySelector(selectorStickersContainer)
+			container: document.querySelector(selectorStickerWindowScroller)
 		});
 	};
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -48,7 +48,9 @@
 	let packsSearch = null;
 	let resizeObserver;
 
-	const settings = {};
+	const settings = {
+		closeWindowOnSend: false
+	};
 
 	// NOTE: For the time being only used to limit keys in replace/export database functions
 	const allowedStorageKeys = [
@@ -364,7 +366,6 @@
 		}
 
 		onCooldown = true;
-		// stickerWindowActive = false;
 
 		try {
 			const userId = modules.userStore.getCurrentUser().id;
@@ -379,6 +380,9 @@
 			}
 
 			toast('Sending\u2026', { nolog: true });
+			if (settings.closeWindowOnSend) {
+				stickerWindowActive = false;
+			}
 
 			const url = formatUrl(pack, id, true);
 			log(`Fetching sticker from remote: ${url}`);
@@ -1253,18 +1257,16 @@
 						</div>
 						{ :else if activeTab === 3 }
 						<SimpleBar class="tabContent misc" style="">
-							<!--
 							<div class="section settings" on:change="{ onSettingsChange }">
 								<p class="section-title">Settings</p>
 								<p>
 									<input
-										name="name"
+										name="closeWindowOnSend"
 										type="checkbox"
-										bind:checked={ settings.name } />
-									<label for="name">Option description</label>
+										bind:checked={ settings.closeWindowOnSend } />
+									<label for="closeWindowOnSend">Close window when sending a sticker</label>
 								</p>
 							</div>
-							-->
 							<div class="section database">
 								<p class="section-title">Database</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1121,6 +1121,7 @@
 							alt="{ pack.id } - { sticker }"
 							on:click="{ () => sendSticker(pack.id, sticker) }"
 						>
+						{ #if favoriteStickers.findIndex(f => f.pack === pack.id && f.id === sticker) === -1 }
 						<div class="addFavorite"
 							title="Favorite"
 							on:click="{ () => favoriteSticker(pack.id, sticker) }">
@@ -1128,6 +1129,15 @@
 								<path fill="grey" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
 							</svg>
 						</div>
+						{ :else }
+						<div class="deleteFavorite"
+							title="Unfavorite"
+							on:click="{ () => unfavoriteSticker(pack.id, sticker) }">
+							<svg width="20" height="20" viewBox="0 0 24 24">
+								<path fill="grey" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"></path>
+							</svg>
+						</div>
+						{ /if }
 					</div>
 					{ /each }
 				</div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -947,7 +947,7 @@
 	};
 
 	const onSettingsChange = event => {
-		const name = event.target.name;
+		const { name } = event.target;
 		if (!name) return false;
 
 		// Value already changed via Svelte's bind:value
@@ -958,8 +958,8 @@
 	};
 
 	const onReplaceDatabaseChange = event => {
-		const file = event.target.files[0];
-		if (!file) return false;
+		const { files } = event.target;
+		if (!files.length) return false;
 
 		const reader = new FileReader();
 		reader.onload = e => {
@@ -1041,8 +1041,8 @@
 			);
 		};
 
-		log(`Reading ${file.name}\u2026`);
-		reader.readAsText(file);
+		log(`Reading ${files[0].name}\u2026`);
+		reader.readAsText(files[0]);
 	};
 
 	const replaceDatabase = () => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -49,6 +49,7 @@
 	let resizeObserver;
 
 	const settings = {
+		disableToasts: false,
 		closeWindowOnSend: false,
 		disableDownscale: false
 	};
@@ -65,11 +66,13 @@
 		console[type]('%c[Magane]%c', 'color: #3a71c1; font-weight: 700', '', message);
 
 	const toast = (message, options = {}) => {
-		if (!options.nolog) {
+		if (!options.nolog || settings.disableToasts) {
 			const type = ['log', 'info', 'warn', 'error'].includes(options.type) ? options.type : 'log';
 			log(message, type);
 		}
-		BdApi.showToast(message, options);
+		if (!settings.disableToasts) {
+			BdApi.showToast(message, options);
+		}
 	};
 
 	const toastInfo = (message, options = {}) => {
@@ -1264,6 +1267,13 @@
 						<SimpleBar class="tabContent misc" style="">
 							<div class="section settings" on:change="{ onSettingsChange }">
 								<p class="section-title">Settings</p>
+								<p>
+									<input
+										name="disableToasts"
+										type="checkbox"
+										bind:checked={ settings.disableToasts } />
+									<label for="disableToasts">Disable Toasts</label>
+								</p>
 								<p>
 									<input
 										name="closeWindowOnSend"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -450,17 +450,16 @@
 	};
 
 	const favoriteSticker = (pack, id) => {
-		for (const favorite of favoriteStickers) {
-			if (favorite.id === id) {
-				return toastError('This sticker is already in your favorites.');
-			}
-		}
+		const index = favoriteStickers.findIndex(f => f.pack === pack && f.id === id);
+		if (index !== -1) return;
 
 		if (!favoriteStickersData[pack]) {
 			const data = subscribedPacks.find(p => p.id === pack);
-			favoriteStickersData[pack] = {
-				name: data && data.name
-			};
+			if (data) {
+				favoriteStickersData[pack] = {
+					name: data.name
+				};
+			}
 		}
 
 		const favorite = { pack, id };
@@ -471,19 +470,11 @@
 	};
 
 	const unfavoriteSticker = (pack, id) => {
-		let found = false;
-		for (const favorite of favoriteStickers) {
-			if (favorite.id === id) found = true;
-		}
+		const index = favoriteStickers.findIndex(f => f.pack === pack && f.id === id);
+		if (index === -1) return;
 
-		if (!found) return;
-
-		for (let i = 0; i < favoriteStickers.length; i++) {
-			if (favoriteStickers[i].id === id) {
-				favoriteStickers.splice(i, 1);
-				favoriteStickers = favoriteStickers;
-			}
-		}
+		favoriteStickers.splice(index, 1);
+		favoriteStickers = favoriteStickers;
 
 		if (!favoriteStickers.some(s => s.pack === pack)) {
 			delete favoriteStickersData[pack];
@@ -1103,7 +1094,7 @@
 							class="image"
 							src="{ `${formatUrl(sticker.pack, sticker.id)}` }"
 							alt="{ sticker.pack } - { sticker.id }"
-							title="{ favoriteStickersData[sticker.pack].name }"
+							title="{ favoriteStickersData[sticker.pack] ? favoriteStickersData[sticker.pack].name : 'N/A' }"
 							on:click="{ () => sendSticker(sticker.pack, sticker.id) }"
 						>
 						<div class="deleteFavorite"

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -63,6 +63,12 @@ div#magane {
 			margin-bottom: 100px;
 			position: relative;
 
+			&.has-left-toolbar {
+				height: 650px !important;
+				margin-bottom: 0;
+				margin-left: 50px;
+			}
+
 			h3.getStarted {
 				text-align: center;
 				padding-top: 40%;
@@ -124,6 +130,7 @@ div#magane {
 							}
 						}
 					}
+
 					div.addFavorite {
 						bottom: 0;
 						&:hover {
@@ -132,6 +139,7 @@ div#magane {
 							}
 						}
 					}
+
 					div.deleteFavorite {
 						top: 0px;
 						transform: rotateZ(45deg);
@@ -152,31 +160,55 @@ div#magane {
 			}
 		}
 
-		div.bottom-toolbar {
+		div.packs-toolbar {
 			position: absolute;
 			bottom: 0;
-			width: 100%;
-			height: 50px;
 			background: $backgroundSecondary;
 			display: flex;
-		}
 
-		div.packs {
-			flex: 1 0 auto;
-			overflow: auto hidden;
-
-			&.packs-controls {
-				flex-grow: 0;
-			}
-
-			div.packs-wrapper {
-				white-space: nowrap;
-				float: left;
+			&.bottom-toolbar {
 				width: 100%;
-				font-size: 0; /* quick hax to clear whitespace */
+				height: 50px;
+
+				div.packs {
+					flex: 1 0 auto;
+					overflow: auto hidden;
+
+					&.packs-controls {
+						flex: 0 0 auto;
+					}
+
+					div.packs-wrapper {
+						white-space: nowrap;
+						float: left;
+						width: 100%;
+						font-size: 0; /* quick hax to clear whitespace */
+					}
+				}
 			}
 
-			div.pack {
+			&.left-toolbar {
+				width: 50px;
+				height: 100%;
+				flex-direction: column;
+
+				div.packs {
+					flex: 1 1 auto;
+					overflow: hidden auto;
+					height: 100%;
+
+					&.packs-controls {
+						flex: 0 0 auto;
+						height: auto;
+					}
+
+					div.packs-wrapper {
+						font-size: 0; /* quick hax to clear whitespace */
+					}
+				}
+			}
+
+			div.packs div.pack {
 				display: inline-block;
 				height: 40px;
 				width: 40px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -309,10 +309,15 @@ div#magane {
 					}
 				}
 
-				div.tabContent {
+				div.tab-content {
 					height: 100%;
 					width: 100%;
 					overflow-y: auto;
+
+					&.avail-packs {
+						display: flex;
+						flex-direction: column;
+					}
 
 					&.line-proxy {
 						display: flex;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -38,6 +38,9 @@ div#magane {
 	img.channel-textarea-stickers-content {
 		width: 24px;
 		height: 24px;
+		padding: 4px;
+		margin-left: 2px;
+		margin-right: 2px;
 	}
 
 	div.stickerWindow {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,13 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@jbfulgencio/svelte-simplebar@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@jbfulgencio/svelte-simplebar/-/svelte-simplebar-1.0.0.tgz#cf5939d5edeabb35db06a14d114a96f9b5a45e5d"
+  integrity sha512-TT7Q7KxEK8MLijXmPCrwZhSFXv8cqeeI8pkc5gC8iAnNmWsJ/IS1eMsoYm3K0JSFghOjQghXZndgKLe81hXqKQ==
+  dependencies:
+    simplebar "^5.1.0"
+
 "@rollup/plugin-commonjs@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.0.tgz#a6675e56094ac9c797c19a3986378289396a9dd5"
@@ -85,13 +92,6 @@
   integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
   dependencies:
     "@types/node" "*"
-
-"@woden/svelte-simplebar@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@woden/svelte-simplebar/-/svelte-simplebar-1.0.0.tgz#05df3326cc30b96e9cda2d5943b5e94ed97db4e7"
-  integrity sha512-YYr5JhmqNnNpk2E0Uf1nE8ObUmR072b175s1A3G5WTmeiyLfKbhmTYx2vfZh4vrljDtuWt1f+79e/s6ybrS4Eg==
-  dependencies:
-    simplebar "^5.1.0"
 
 acorn-jsx@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
![image](https://i.fiery.me/stickers/fierygenshinmix1/41.png)

**Comes with THREE new settings for free!**

![image](https://user-images.githubusercontent.com/9364930/164185491-6185983c-b1a6-463b-b75b-74c18c6e12de.png)

---

refactor: replace/export database @ https://github.com/Pitu/Magane/commit/4325450989794a5ca4fabcc7fe50b47d803a5258

still the same functionality, just changed UI text formatting to appear clearer to end-users (since it actually supports Discord's Markdown), and a bit more checks against edge cases

![image](https://user-images.githubusercontent.com/9364930/164185969-7ba66a71-d9a5-49b1-a3ad-08f57e7a330f.png)

---

ci: update github actions @ https://github.com/Pitu/Magane/commit/dc5cc530e1deed7ed94b163f99c49e7efd0a4d44 + https://github.com/Pitu/Magane/pull/57/commits/2678276c3c186a1819303a30e8084d533d38f5e1

essentially still the same final behavior

instead of using `actions/cache` directly, we instead simply use an option under `actions/setup-node` that does the exact same thing, as it actually uses `actions/cache` under the hood ([reference](https://github.com/actions/setup-node/tree/v3.1.1#caching-global-packages-data))

`actions/checkout@v3` has no breaking updates since `v2`, at least with our specific use-case (using GitHub's public actions runtime instead of own GHES) ([reference](https://github.com/actions/checkout/releases))

can personally [vouch](https://github.com/BobbyWibowo/lolisafe/blob/9af52e068dea48ffaae834ce9febcfd47345d0de/.github/workflows/build.yml) for those two

not touching `EndBug/add-and-commit` since i don't use it on my own projects, and i see plenty of breaking updates since `v6`

---

perf: no more rebuilding UIs everytime, faster! @ https://github.com/Pitu/Magane/pull/57/commits/f05fd16ef6da7347b38e7aa352d6be4efdcb73cb

previously, we would always rebuild UI DOMs every time we toggle magane window (very significant impact to responsiveness the more packs you have subscribed to)
and this doesn't only happen with the main window, but also packs list in the add stickers menu

now main window DOM will be initiated immediately, and toggling its display will now simply toggle its `display` css property

packs list (installed and packs tabs) will be initiated for the first time on demand (when user actually activates the add sticker window and/or the tab), then subsequent activation will toggle their `display` css properties instead

`tabContent` refactored to `tab-content`, maybe one day we will have the other camelCase class names consistently be kebab-case too :(