### PR TITLE
Pr 3.2.2 hotkey fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
When set to single key (e.g. M), it used to listen to combos too (e.g. Ctrl+M, Ctrl+Alt+M, etc.)
Also added support for listening to only certain side's keys (left ctrl, right alt, etc.), and made the input box for hotkey not to trigger existing hotkey as you're editing it