### PR TITLE
3.2.3 logic to handle offline magane API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
sending custom packs and everything else will work just fine, just that magane's built-in packs will temporarily be unavailable, and they'll be presented with relevant error messages on first load, and when trying to send any magane's built-in packs' stickers (if they had any subscribed)

![image](https://i.fiery.me/f8KD.png)

red crosses as placeholder thumbs for magane's built-in packs when the API is down