### PR TITLE
3.2.4 fix with voice channel's text chat wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -980,7 +980,7 @@
 
 	const toggleStickerWindow = forceState => {
 		if (!document.body.contains(main)) {
-			return toastError('Oh no! Magane was unexpectedly destroyed. Please reload Magane :(', { timeout: 6000 });
+			return toastError('Oh no! Magane was unexpectedly destroyed.. Please consider updating to MaganeBD instead.', { timeout: 6000 });
 		}
 		const active = typeof forceState === 'undefined' ? !stickerWindowActive : forceState;
 		if (active) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -41,16 +41,18 @@
 	let storage = null;
 	let packsSearch = null;
 	let resizeObserver = null;
+	let isWarnedAboutViewportHeight = false;
 	const waitForTimeouts = {};
 
 	const settings = {
 		disableToasts: false,
 		closeWindowOnSend: false,
-		disableDownscale: false,
 		useLeftToolbar: false,
+		hidePackAppendix: false,
+		disableDownscale: false,
 		disableImportedObfuscation: false,
 		markAsSpoiler: false,
-		hidePackAppendix: false,
+		ignoreViewportSize: false,
 		hotkey: null
 	};
 	const defaultSettings = Object.freeze(Object.assign({}, settings));
@@ -986,6 +988,14 @@
 		if (active) {
 			updateStickerWindowPosition();
 			document.addEventListener('click', maganeBlurHandler);
+			// One-time warning for viewport height <= 700px when opening Magane window
+			if (!settings.ignoreViewportSize && !isWarnedAboutViewportHeight) {
+				const viewportHeight = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+				if (viewportHeight <= 700) {
+					toastWarn('Viewport height is less than 700px, Magane window may not display properly.', { timeout: 6000 });
+					isWarnedAboutViewportHeight = true;
+				}
+			}
 		} else {
 			document.removeEventListener('click', maganeBlurHandler);
 		}
@@ -1916,6 +1926,15 @@
 											type="checkbox"
 											bind:checked={ settings.markAsSpoiler } />
 										Mark stickers as spoilers when sending
+									</label>
+								</p>
+								<p>
+									<label>
+										<input
+											name="ignoreViewportSize"
+											type="checkbox"
+											bind:checked={ settings.ignoreViewportSize } />
+										Do not warn if viewport height is insufficient
 									</label>
 								</p>
 							</div>


### PR DESCRIPTION
Fix for https://discord.com/channels/361432183010754562/363877247100387329/1021111469959565492 in Discord

---

Added viewport height check to avoid confusion such as in https://discord.com/channels/361432183010754562/363877247100387329/1020321585627926538

![image](https://i.fiery.me/CNYq.png)
Warning toast about it will only appear **once** when opening Magane
Also added a preference setting to disable the check altogether for those that want to use Custom CSS to override the window size anyway
I'm too lazy to make the window more dynamic instead, haha