### PR TITLE
3.2.6 frequently used section + improved database hot-reload logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2069,7 +2069,10 @@
 							<div class="section frequently-used">
 								<p class="section-title">Frequently Used</p>
 								<p>
-									Set to <code>0</code> to disable Frequently Used and stickers usage counter.
+									Maximum amount of the most frequently used stickers to list on Frequently Used section.
+								</p>
+								<p>
+									Set to <code>0</code> to completely disable the section and stickers usage counter.
 								</p>
 								<p class="input-grouped">
 									<input

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -327,8 +327,8 @@
 			// would also store remote built-in packs in local storage (no idea why).
 			const filteredLocalPacks = availLocalPacks.filter(pack =>
 				typeof pack === 'object' &&
-					typeof pack.id !== 'undefined' &&
-					localPackIdRegex.test(pack.id));
+				typeof pack.id !== 'undefined' &&
+				localPackIdRegex.test(pack.id));
 			if (availLocalPacks.length !== filteredLocalPacks.length) {
 				saveToLocalStorage('magane.available', filteredLocalPacks);
 			}
@@ -1543,8 +1543,9 @@
 		if (save) {
 			settings.hotkey = hotkeyInput;
 			log(`settings['hotkey'] = ${settings.hotkey}`);
+
 			saveToLocalStorage('magane.settings', settings);
-			toastSuccess(hotkey ? 'Hotkey saved.' : 'Hotkey cleared.');
+			toastSuccess(hotkey ? 'Hotkey saved.' : 'Hotkey cleared.', { nolog: true });
 		}
 	};
 
@@ -1653,7 +1654,7 @@
 			const database = {};
 			for (const key of allowedStorageKeys) {
 				const data = getFromLocalStorage(key);
-				if (data !== undefined) {
+				if (typeof data !== 'undefined') {
 					database[key] = data;
 				}
 			}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -199,23 +199,28 @@ div#magane {
 				}
 
 				> div {
-					background-image: url('/assets/f24711dae4f6d6b28335e866a93e9d9b.png');
-					width: 22px;
-					height: 22px;
-					background-size: 924px 704px;
+					background-image: url('/assets/62ed7720accb1adfe95565b114e843c6.png');
+					width: 32px;
+					height: 32px;
+					background-size: 1344px 1216px;
 					background-repeat: no-repeat;
-					margin-top: 8px;
-					margin-left: 9px;
+					margin-top: 4px;
+					margin-left: 4px;
 				}
 
 				div.icon-favorite {
-					background-position: -462px -132px;
+					background-position: -1056px -288px;
 				}
 
 				div.icon-plus {
-					background-position: -374px -484px;
+					background-position: -384px -896px;
 					/* make it greenish */
-					filter: hue-rotate(260deg) brightness(3) contrast(4.5);
+					/* thanks to the magic of https://codepen.io/sosuke/pen/Pjoqqp */
+					filter: invert(63%) sepia(25%) saturate(813%) hue-rotate(55deg) brightness(98%) contrast(82%);
+				}
+
+				div.icon-frequently-used {
+					background-position: -160px -960px;
 				}
 			}
 		}
@@ -625,6 +630,15 @@ div#magane {
 				background: rgba($scrollbarColor, 1);
 			}
 		}
+	}
+
+	code {
+		box-sizing: border-box;
+		padding: 2px 6px;
+		border-radius: 3px;
+		border: 1px solid $backgroundPrimary;
+		background: $backgroundPrimary;
+		color: $textColor;
 	}
 }
 


### PR DESCRIPTION
Frequently Used section:
![image](https://i.fiery.me/Bv0Q.png)
Hidden by default (including the clock shortcut for it on the left/bottom toolbars), until user sends a sticker successfully, unless Frequently Used is explicitly disabled (via the new setting below)

Added 1 new setting:
![image](https://i.fiery.me/DiuO.png)
Defaults to **10**

---

Also improved database hot-reload logic
Previously, when replacing databases, depending on how "complete" the last or the new databases are, some settings may not completely reset to defaults
Some local arrays/objects that Svelte builds the DOM upon used to not reset properly sometimes either