### PR TITLE
3.2.9 temporary alternative to mitigate uploads breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -555,6 +555,7 @@
 		return url;
 	};
 
+	// eslint-disable-next-line no-unused-vars
 	const getTextAreaInstance = () => {
 		// NOTE: If any deeper than the 10th step, then Discord must be changing something again,
 		// thus better to inspect further instead of blindly increasing the limit.
@@ -643,7 +644,8 @@
 			const file = new File([blob], filename);
 			log(`Sending sticker as ${filename}\u2026`);
 
-			let messageContent = '';
+			/* SKIP -- CANNOT ATTACH TEXT MESSAGE TO UPLOADS
+			const messageContent = '';
 			let textAreaInstance;
 			if (!settings.disableSendingWithChatInput) {
 				textAreaInstance = getTextAreaInstance();
@@ -659,6 +661,7 @@
 				}
 			}
 
+			// BROKEN -- UNRESPONSIVE, WAITING FOR INVESTIGATION
 			modules.messageUpload.upload({
 				channelId,
 				file,
@@ -667,6 +670,11 @@
 					tts: false
 				}
 			});
+			*/
+
+			// TEMPORARY ALTERNATIVE (CANNOT ATTACH TEXT MESSAGE)
+			log('Temporarily sending sticker without message content due to a bug...');
+			modules.messageUpload.instantBatchUpload(channelId, [file]);
 
 			// Update sticker's usage stats if using Frequently Used
 			if (settings.frequentlyUsed !== 0) {
@@ -685,6 +693,7 @@
 			}
 
 			// Clear chat input if required
+			/*
 			if (!settings.disableSendingWithChatInput && textAreaInstance) {
 				textAreaInstance.stateNode.setState({
 					textValue: '',
@@ -692,6 +701,7 @@
 					richValue: [{ type: 'line', children: [{ text: '' }] }]
 				});
 			}
+			*/
 		} catch (error) {
 			console.error(error);
 			toastError(error.toString(), { nolog: true, timeout: 5000 });


### PR DESCRIPTION
Related bug report: https://discord.com/channels/361432183010754562/363877247100387329/1061526826490544198

An alternative method to upload the stickers

Unfortunately, due to it seemingly intended for batch uploads, it has no option to attach text messages into the uploads, so that particular part of the feature is currently disabled

A stop-gap fix as I await investigation results from other similar projects