### PR TITLE
3.2.10 better fetching of discord modules, discord permissions check, send stickers as links, split-view support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2159,7 +2159,7 @@
 											name="disableImportedObfuscation"
 											type="checkbox"
 											bind:checked={ settings.disableImportedObfuscation } />
-										Disable obfuscation of files names for imported custom packs
+										Disable obfuscation of files names for imported custom packs (obfuscation happens only for uploads)
 									</label>
 								</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -659,8 +659,13 @@
 					toastWarn('You do not have permission to attach files, sending sticker as link\u2026');
 				}
 
+				let append = url;
+				if (settings.markAsSpoiler) {
+					append = `||${append}||`;
+				}
+
 				Modules.SendMessage.sendMessage(channelId, {
-					content: `${messageContent} ${url}`.trim()
+					content: `${messageContent} ${append}`.trim()
 				});
 			} else {
 				toastError('You do not have permissions to attach files nor embed links.');
@@ -2181,7 +2186,7 @@
 											name="markAsSpoiler"
 											type="checkbox"
 											bind:checked={ settings.markAsSpoiler } />
-										Mark stickers as spoilers when sending (only for uploads)
+										Mark stickers as spoilers when sending
 									</label>
 								</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -299,7 +299,7 @@
 	const initModules = () => {
 		// Channel store & actions
 		Modules.ChannelStore = BdApi.findModuleByProps('getChannel', 'getDMFromUserId');
-		// Modules.SelectedChannelStore = BdApi.findModuleByProps('getLastSelectedChannelId'); // TODO
+		Modules.SelectedChannelStore = BdApi.findModuleByProps('getLastSelectedChannelId');
 
 		// Permissions
 		Modules.DiscordConstants = BdApi.findModuleByProps('Permissions', 'ActivityTypes', 'StatusTypes');
@@ -681,7 +681,7 @@
 			// Good ol' reliable
 			// const channelId = window.location.href.split('/').slice(-1)[0];
 
-			// If multiple active channels, SelectedChannelStore will only return the main channel,
+			// If multiple active channels (i.e. split-view), SelectedChannelStore will only return the main channel,
 			// so determining through active component's textArea instance is more reliable, if available.
 			let channelId;
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -188,9 +188,8 @@
 		if (entry && entry.contentRect.width !== 0 && entry.contentRect.height !== 0) {
 			for (const component of components) {
 				if (component.textArea === entry.target) {
-					// Skip worker only if entry's size still matches last size
-					if ((component.lastTextAreaSize.width === entry.contentRect.width) &&
-						(component.lastTextAreaSize.height === entry.contentRect.height)) {
+					// Skip worker only if entry's width still matches last width (ignore height)
+					if (component.lastTextAreaSize.width === entry.contentRect.width) {
 						return;
 					}
 					break;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,9 +15,9 @@
 	let main = null;
 	let base = null;
 	let isMaganeBD = null;
+	let forceHideMagane = false;
 	let components = [];
 	let activeComponent = null;
-	let hideMagane = false;
 
 	let baseURL = '';
 	let stickerWindowActive = false;
@@ -1874,7 +1874,7 @@
 							storage.removeItem(key);
 						}
 
-						hideMagane = true;
+						forceHideMagane = true;
 						toast('Reloading Magane database\u2026');
 
 						Object.assign(settings, defaultSettings);
@@ -1883,7 +1883,7 @@
 						await migrateStringPackIds();
 
 						toastSuccess('Magane is now ready!');
-						hideMagane = false;
+						forceHideMagane = false;
 					}
 				}
 			);
@@ -1929,7 +1929,7 @@
 
 <main bind:this={ main }>
 	<div id="magane"
-		style="{ isMaganeBD ? '' : `top: ${coords.top}px; left: ${coords.left}px;` } { hideMagane ? 'display: none;' : ''}">
+		style="{ isMaganeBD ? '' : `top: ${coords.top}px; left: ${coords.left}px;` } { forceHideMagane ? 'display: none;' : ''}">
 
 		<div class="stickerWindow" style="bottom: { `${coords.wbottom}px` }; right: { `${coords.wright}px` }; { stickerWindowActive ? '' : 'display: none;' }">
 			<div class="stickers has-scroll-y { settings.useLeftToolbar ? 'has-left-toolbar' : '' }" style="">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -597,7 +597,9 @@
 		try {
 			initComponentDispatch();
 
-			const channelId = Modules.SelectedChannelStore.getChannelId();
+			// const channelId = Modules.SelectedChannelStore.getChannelId();
+			// Good ol' reliable
+			const channelId = window.location.href.split('/').slice(-1)[0];
 
 			if (!hasPermission('SEND_MESSAGES', channelId)) {
 				onCooldown = false;

--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -7,6 +7,11 @@
 	export let element;
 	export let active = false;
 
+	// svelte-ignore unused-export-let
+	export let textArea = undefined;
+	// svelte-ignore unused-export-let
+	export let lastTextAreaSize = {};
+
 	const dispatch = createEventDispatcher();
 
 	const log = message =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,15 +436,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001017:
-  version "1.0.30001021"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001021.tgz#e75ed1ef6dbadd580ac7e7720bb16f07b083f254"
-  integrity sha512-wuMhT7/hwkgd8gldgp2jcrUjOU9RXJ4XxGumQeOsUr91l3WwmM68Cpa/ymCnWEDqakwFXhuDQbaKNHXBPgeE9g==
-
-caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001358:
-  version "1.0.30001358"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz#473d35dabf5e448b463095cab7924e96ccfb8c00"
-  integrity sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001358:
+  version "1.0.30001446"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001446.tgz"
+  integrity sha512-fEoga4PrImGcwUUGEol/PoFCSBnSkA9drgdkxXkJLsUBOnJ8rs3zDv6ApqYXGQFOyMPsjh79naWhF4DAxbF8rw==
 
 chalk@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
- Better fetching of Discord modules
i.e. fetching of chat input, etc., are now done via calling the appropriate Discord/Webpack modules instead of through React/DOM hacks
- Sending stickers now properly include chat input again
- 2 new options (the ones in the middle):
![screenshot](https://i.fiery.me/JywW.png)

- Restored Discord Permissions check, with always-true fallback if the necessary modules cannot be found (i.e. if Discord changes anything related to permission in the future, at the very least Magane will still always try to send the stickers as-is)
- If user has SEND_MESSAGES permission, but not ATTACH_FILES permission, Magane will automatically fallback into sending the stickers as links
- If the user also has no EMBED_LINKS permission, Magane will cancel sending (since the links will have no previews anyways), but this behavior can be forcefully suppressed via option if the user desires
- Split-view support
![screenshot](https://i.fiery.me/KO37.png)
- Pack info button for custom packs
Description field had always been available for custom packs, but I never had the time to actually make them viewable through the UI before
![screenshot](https://i.fiery.me/CLjn.png)

---

Closes #82