### PR TITLE
feat: 3.2.13 bug fixes + more hacks for vencord plugin edition

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,12 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.md]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = false
+
 [*.json]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build application (BetterDiscord plugin)
         run: yarn build-bd
 
+      - name: Build application (Vencord plugin)
+        run: yarn build-vc
+
       - uses: EndBug/add-and-commit@v6
         with:
           branch: master

--- a/README.md
+++ b/README.md
@@ -26,26 +26,23 @@ Currently the best way to get this up and running is by using [BetterDiscord](ht
 
 #### BetterDiscord
 
-- Grab the prebuilt plugin file from [https://magane.moe/api/dist/betterdiscord](https://magane.moe/api/dist/.etterdiscord).
-- Place it in your **plugins** directory.
-- Activate it from Discord's **User Settings > BetterDiscord > Plugins**.
+- Grab the pre-built plugin file from [https://magane.moe/api/dist/betterdiscord](https://magane.moe/api/dist/.etterdiscord).
+- Place the plugin file into your BetterDiscord's **plugins** directory.
+- Activate Magane from Discord's **User Settings > BetterDiscord > Plugins**.
 
 #### Vencord
 
 > This is for the more advanced users.  
 > Be advised that Magane's update checker is not available on Vencord.
 
-- Grab `magane.vencord.js` from [dist](tree/master/dist) directory.
+- Grab the pre-built plugin file, `magane.vencord.js`, from this repo's dist directory, [https://github.com/Pitu/Magane/tree/master/dist](https://github.com/Pitu/Magane/tree/master/dist).
 - Download Vencord git from `https://github.com/Vendicated/Vencord`.
-- In Vencord Git directory, navigate to `src`, and create `userplugins` directory (e.g. `/path/to/vencord/src/userplugins`).
+- Follow its advanced user's installation guide at `https://github.com/Vendicated/Vencord/blob/main/docs/1_INSTALLING.md`.
+- In Vencord git directory, navigate to `src`, then create `userplugins` directory (e.g. `/path/to/vencord/src/userplugins`).
 - Drop Magane plugin into it.
-- Build Vencord, then inject it into your Discord installation.
-    ```sh
-    pnpm install --frozen-lockfile
-    pnpm build
-    pnpm inject
-    ```
-- Activate it from Discord's **User Settings > Vencord > Plugins**.
+- Rebuild Vencord (`pnpm build`), then restart your Discord.
+- Optionally, if you had not done it before, you must inject Vencord into your Discord installation (`pnpm inject`).
+- Activate Magane from Discord's **User Settings > Vencord > Plugins**.
 
 ### So how exactly do I use it after adding the script?
 

--- a/README.md
+++ b/README.md
@@ -8,27 +8,48 @@
 [![Support me](https://img.shields.io/badge/Support-Buy%20me%20a%20coffee-yellow.svg?style=flat-square)](https://www.buymeacoffee.com/kana)
 
 ### What does this do?
+
 You know how LINE and Telegram have this beautiful sticker system where you can send different reactions with just one click? This is a new approach at doing exactly that but on Discord!
 
 [It looks like this](https://chibisafe.moe/owdxQF9m.mp4)
 
 ### How even?
+
 By injecting the script into Discord it will automatically pull a curated list of sticker packs from [chibisafe](https://chibisafe.moe) and add them to your Discord client. After that a heart button will appear in your message bar where you'll be able to see all the stickers!
 
+
 ### Can I make this permanent?
-You can! Currently the best way to get this up and running is by using [BetterDiscord](https://github.com/rauenzi/BetterDiscordApp/releases) . Make sure to head to the [Magane website](https://magane.moe) for instructions on how to install it. If you have another injector already set up and running you could theoretically just feed it the Magane script and see if it works:
-```
-https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.min.js
-```
+
+You can!
+
+Currently the best way to get this up and running is by using [BetterDiscord](https://github.com/rauenzi/BetterDiscordApp/releases), but we also have experimental support for [Vencord](https://vencord.dev/).
+
+#### BetterDiscord
+
+- Grab the prebuilt plugin file from [https://magane.moe/api/dist/betterdiscord](https://magane.moe/api/dist/.etterdiscord).
+- Place it in your **plugins** directory.
+- Activate it from Discord's **User Settings > BetterDiscord > Plugins**.
+
+#### Vencord
+
+> This is for the more advanced users.  
+> Be advised that Magane's update checker is not available on Vencord.
+
+- Grab `magane.vencord.js` from [dist](tree/master/dist) directory.
+- Download Vencord git from `https://github.com/Vendicated/Vencord`.
+- In Vencord Git directory, navigate to `src`, and create `userplugins` directory (e.g. `/path/to/vencord/src/userplugins`).
+- Drop Magane plugin into it.
+- Build Vencord, then inject it into your Discord installation.
+    ```sh
+    pnpm install --frozen-lockfile
+    pnpm build
+    pnpm inject
+    ```
+- Activate it from Discord's **User Settings > Vencord > Plugins**.
 
 ### So how exactly do I use it after adding the script?
+
 It's very easy.
 After opening the sticker popup click on the little tool icon and you'll see a list of available sticker packs. Clicking on a sticker pack will subscribe you to it, making every sticker on that pack available on the main window. You can also right click any sticker in the list and add them to your favorites for easy access! To remove one, right click on it again.
 
-### Give me the code, I want to run this right now!
-Press `Ctrl + Shift + i` or `CMD + Option + i` to open DevTools, and paste the following code inside:
-```js
-document.head.appendChild(document.createElement('script')).setAttribute("src", "https://magane.moe/api/dist/magane")
-```
-
-> Injecting random code into your Discord client could be harmful, that's why I provide the full source code so you can check out exactly what the script does. This plugin makes use of your personal token to make a request to the Discord api each time you click a sticker and never leaves nor does it do anything else with it. The script found in `/dist` is generated, webpacked and babeled from the source by running `npm run webpack`.
+Or just watch [the preview](https://chibisafe.moe/owdxQF9m.mp4) again.

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "build-bd": "rollup -c rollup-bd.config.js",
-    "dev-bd": "rollup -c rollup-bd.config.js -w"
+    "dev-bd": "rollup -c rollup-bd.config.js -w",
+    "build-vc": "rollup -c rollup-vencord.config.js",
+    "dev-vc": "rollup -c rollup-vencord.config.js -w"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
-    "@rollup/plugin-replace": "^4.0.0",
+    "@rollup/plugin-replace": "^5.0.2",
     "eslint": "^6.8.0",
     "eslint-config-aqua": "^7.2.0",
     "eslint-plugin-svelte3": "^2.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/rollup-bd.config.js
+++ b/rollup-bd.config.js
@@ -92,8 +92,7 @@ export default {
 			command(`cp --force "${file}" "${process.env.BD_PLUGIN_PATH}"`, {
 				once: false,
 				wait: true
-			}) &&
-			console.log(`Copied build file to ${process.env.BD_PLUGIN_PATH}`)
+			})
 	],
 	watch: {
 		clearScreen: false

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -2,7 +2,6 @@ import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import command from 'rollup-plugin-command';
-import license from 'rollup-plugin-license';
 import { terser } from 'rollup-plugin-terser';
 import replace from '@rollup/plugin-replace';
 import postcss from 'rollup-plugin-postcss';
@@ -11,11 +10,10 @@ import autoPreprocess from 'svelte-preprocess';
 import path from 'path';
 
 const production = !process.env.ROLLUP_WATCH;
-const file = path.resolve(__dirname, production ? 'dist' : 'dist-dev', 'magane.plugin.js');
-const meta = path.resolve(__dirname, 'src/bd-meta.txt');
+const file = path.resolve(__dirname, production ? 'dist' : 'dist-dev', 'magane.vencord.js');
 
 export default {
-	input: 'src/bd-main.js',
+	input: 'src/vencord-main.js',
 	output: {
 		file,
 		format: 'cjs',
@@ -26,12 +24,6 @@ export default {
 		sourcemap: false
 	},
 	plugins: [
-		!production && {
-			name: 'watch-extras',
-			buildStart() {
-				this.addWatchFile(meta);
-			}
-		},
 		svelte({
 			dev: !production,
 			emitCss: true,
@@ -79,21 +71,45 @@ export default {
 				'    ': '\t'
 			}
 		}),
-		license({
-			banner: {
-				commentStyle: 'regular',
-				content: {
-					file: meta,
-					encoding: 'utf-8'
-				}
+		production && replace({
+			delimiters: ['', ''],
+			preventAssignment: false,
+			values: {
+				'"use strict";': '"use strict"\n__VencordImports__;',
+
+				// This is so hacky, lmao
+				', vencordMain = definePlugin({': ';\n\nexport default definePlugin({',
+				'module.exports = vencordMain;': ''
 			}
 		}),
-		Boolean(process.env.BD_PLUGIN_PATH) &&
-			command(`cp --force "${file}" "${process.env.BD_PLUGIN_PATH}"`, {
+		!production && replace({
+			delimiters: ['', ''],
+			preventAssignment: false,
+			values: {
+				'\'use strict\';': '\'use strict\';\n__VencordImports__;',
+
+				// This is so hacky, lmao
+				'var vencordMain = definePlugin({': 'export default definePlugin({',
+				'module.exports = vencordMain;': ''
+			}
+		}),
+		replace({
+			delimiters: ['', ''],
+			preventAssignment: false,
+			values: {
+				'__VencordImports__;': 'import definePlugin from "@utils/types";\nimport { findByPropsLazy, findLazy } from "@webpack";\nimport { Alerts, Toasts } from "@webpack/common";',
+				'VencordApi.': '',
+
+				// Svelte syntax, lmao..
+				'$$invalidate(0, mountType)': '$$invalidate(0, mountType = MountType.VENCORD)'
+			}
+		}),
+		Boolean(process.env.VENCORD_PLUGIN_PATH) &&
+			command(`cp --force "${file}" "${process.env.VENCORD_PLUGIN_PATH}"`, {
 				once: false,
 				wait: true
 			}) &&
-			console.log(`Copied build file to ${process.env.BD_PLUGIN_PATH}`)
+			console.log(`Copied build file to ${process.env.VENCORD_PLUGIN_PATH}`)
 	],
 	watch: {
 		clearScreen: false

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -75,22 +75,14 @@ export default {
 			delimiters: ['', ''],
 			preventAssignment: false,
 			values: {
-				'"use strict";': '"use strict"\n__VencordImports__;',
-
-				// This is so hacky, lmao
-				', vencordMain = definePlugin({': ';\n\nexport default definePlugin({',
-				'module.exports = vencordMain;': ''
+				'"use strict";': '"use strict"\n__VencordImports__;'
 			}
 		}),
 		!production && replace({
 			delimiters: ['', ''],
 			preventAssignment: false,
 			values: {
-				'\'use strict\';': '\'use strict\';\n__VencordImports__;',
-
-				// This is so hacky, lmao
-				'var vencordMain = definePlugin({': 'export default definePlugin({',
-				'module.exports = vencordMain;': ''
+				'\'use strict\';': '\'use strict\';\n__VencordImports__;'
 			}
 		}),
 		replace({
@@ -101,7 +93,11 @@ export default {
 				'VencordApi.': '',
 
 				// Svelte syntax, lmao..
-				'$$invalidate(0, mountType)': '$$invalidate(0, mountType = MountType.VENCORD)'
+				'$$invalidate(0, mountType)': '$$invalidate(0, mountType = MountType.VENCORD)',
+
+				// This is so hacky, lmao
+				'var vencordMain = definePlugin({': 'export default definePlugin({',
+				'module.exports = vencordMain;': ''
 			}
 		}),
 		Boolean(process.env.VENCORD_PLUGIN_PATH) &&

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -108,8 +108,7 @@ export default {
 			command(`cp --force "${file}" "${process.env.VENCORD_PLUGIN_PATH}"`, {
 				once: false,
 				wait: true
-			}) &&
-			console.log(`Copied build file to ${process.env.VENCORD_PLUGIN_PATH}`)
+			})
 	],
 	watch: {
 		clearScreen: false

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -54,7 +54,7 @@ div#magane {
 				display: flex;
 				flex-flow: wrap;
 				justify-content: center;
-				padding: 25px;
+				padding: 20px;
 				width: 100%;
 				box-sizing: border-box;
 
@@ -605,10 +605,12 @@ div#magane {
 
 	.has-scroll-x {
 		overflow-x: auto;
+		scrollbar-gutter: stable;
 	}
 
 	.has-scroll-y {
 		overflow-y: auto;
+		scrollbar-gutter: stable;
 	}
 
 	::-webkit-scrollbar {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -604,11 +604,11 @@ div#magane {
 	}
 
 	.has-scroll-x {
-		overflow-x: overlay;
+		overflow-x: auto;
 	}
 
 	.has-scroll-y {
-		overflow-y: overlay;
+		overflow-y: auto;
 	}
 
 	::-webkit-scrollbar {

--- a/src/vencord-main.js
+++ b/src/vencord-main.js
@@ -1,0 +1,45 @@
+/* global definePlugin */
+const App = require('./App.svelte');
+
+export default definePlugin({
+	name: 'MaganeVencord',
+	authors: [], // blank, authors for Vencord plugins must be hard-coded in their repo's Constants
+	description: 'Bringing LINE stickers to Discord in a chaotic way. Vencord-plugin edition.',
+
+	log(message, type = 'log') {
+		return console[type]('%c[MaganeVencord]%c', 'color: #3a71c1; font-weight: 700', '', message);
+	},
+
+	start() {
+		for (const id of Object.keys(window.MAGANE_STYLES)) {
+			const style = document.createElement('style');
+			style.id = `${this.constructor.name}-${id}`;
+			style.innerText = window.MAGANE_STYLES[id];
+			document.head.appendChild(style);
+		}
+		this.log('Mounting container into DOM\u2026');
+		this.container = document.createElement('div');
+		this.container.id = 'maganeContainer';
+		document.body.appendChild(this.container);
+		this.app = new App({
+			target: this.container
+		});
+	},
+
+	stop() {
+		if (this.app) {
+			this.log('Destroying Svelte component\u2026');
+			this.app.$destroy();
+		}
+		if (this.container) {
+			this.log('Removing container from DOM\u2026');
+			this.container.remove();
+		}
+		for (const id of Object.keys(window.MAGANE_STYLES)) {
+			const _style = document.head.getElementById(`${this.constructor.name}-${id}`);
+			if (_style) {
+				_style.remove();
+			}
+		}
+	}
+});

--- a/src/vencord-main.js
+++ b/src/vencord-main.js
@@ -1,8 +1,10 @@
 /* global definePlugin */
 const App = require('./App.svelte');
 
+const pluginName = 'MaganeVencord';
+
 export default definePlugin({
-	name: 'MaganeVencord',
+	name: pluginName,
 	authors: [], // blank, authors for Vencord plugins must be hard-coded in their repo's Constants
 	description: 'Bringing LINE stickers to Discord in a chaotic way. Vencord-plugin edition.',
 
@@ -13,7 +15,7 @@ export default definePlugin({
 	start() {
 		for (const id of Object.keys(window.MAGANE_STYLES)) {
 			const style = document.createElement('style');
-			style.id = `${this.constructor.name}-${id}`;
+			style.id = `${pluginName}-${id}`;
 			style.innerText = window.MAGANE_STYLES[id];
 			document.head.appendChild(style);
 		}
@@ -36,7 +38,7 @@ export default definePlugin({
 			this.container.remove();
 		}
 		for (const id of Object.keys(window.MAGANE_STYLES)) {
-			const _style = document.head.getElementById(`${this.constructor.name}-${id}`);
+			const _style = document.head.getElementById(`${pluginName}-${id}`);
 			if (_style) {
 				_style.remove();
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@jridgewell/sourcemap-codec@^1.4.13":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@rollup/plugin-commonjs@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.1.0.tgz#60636c7a722f54b41e419e1709df05c7234557ef"
@@ -69,13 +74,13 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-replace@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz#e34c457d6a285f0213359740b43f39d969b38a67"
-  integrity sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==
+"@rollup/plugin-replace@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz#45f53501b16311feded2485e98419acb8448c61d"
+  integrity sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==
   dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    magic-string "^0.25.7"
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.27.0"
 
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
@@ -86,6 +91,15 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rollup/pluginutils@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
+
 "@types/estree@*":
   version "0.0.41"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.41.tgz#fd90754150b57432b72bf560530500597ff04421"
@@ -95,6 +109,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
 "@types/node@*":
   version "13.1.2"
@@ -437,9 +456,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001358:
-  version "1.0.30001446"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001446.tgz"
-  integrity sha512-fEoga4PrImGcwUUGEol/PoFCSBnSkA9drgdkxXkJLsUBOnJ8rs3zDv6ApqYXGQFOyMPsjh79naWhF4DAxbF8rw==
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -1130,6 +1149,11 @@ estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1956,6 +1980,13 @@ magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
+
 magic-string@~0.26.2:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.2.tgz#5331700e4158cd6befda738bb6b0c7b93c0d4432"
@@ -2348,7 +2379,7 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-picomatch@^2.2.2:
+picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==


### PR DESCRIPTION
I think Discord is programmatically doing styling to scrollbars globally, and the fact that we were using outdated CSS value for `overflow` ([ref](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#values)) might've caused it to fail under certain conditions

Seems to work fine after updating these

**EDIT:** Not ready, turns out using `overlay` was a conscious choice on my end due to styling quirks..

**EDIT 2:** Seems ok with commit https://github.com/Pitu/Magane/pull/87/commits/978e2399d423900e2c62ec553e667c8627a89ce0, but PR pending indefinitely until one day if there are other things to add/fix in the future, since this issue in particular is non-critical

---

**EDIT 3**: I think this should be ready 🤔 

This will now also cause GitHub Actions to build Vencord plugin into `dist` directory by the name `magane.vencord.js`. The README.md file has been updated for better install instructions, for both BetterDiscord and Vencord.

I took away the very old install instruction about injecting into browser, since it had stopped working long ago (ever since the switch to using BetterDiscord APIs).

Interestingly enough, Vencord is intended to work on browser, so the Vencord plugin may or may not just work right away there. No time nor interest to test for now however.