### PR TITLE
Pr 3.2.15 fix updating chibisafe albums packs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.14",
+  "version": "3.2.15",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Had to rethink my initial design of determining then saving the API url during the first time a custom remote pack gets added.

Now it'll always determine the API url even when attempting to update, to allow changing it in the future, if ever required, without breaking existing packs.

This will also cleanly "upgrade" any existing old lolisafe/chibisafe album packs when clicking the Update button on any of them.