### PR TITLE
Pr 3.2.16 fix custom json packs + feat mask sticker links with markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-svelte3": "^2.7.3",
     "postcss-preset-env": "^6.7.0",
     "rollup": "^1.32.1",
-    "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-license": "^2.8.1",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-postcss": "^v2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.15",
+  "version": "3.2.16",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/rollup-bd.config.js
+++ b/rollup-bd.config.js
@@ -1,13 +1,13 @@
 import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import command from 'rollup-plugin-command';
 import license from 'rollup-plugin-license';
 import { terser } from 'rollup-plugin-terser';
 import replace from '@rollup/plugin-replace';
 import postcss from 'rollup-plugin-postcss';
 import postcssPresetEnv from 'postcss-preset-env';
 import autoPreprocess from 'svelte-preprocess';
+import fs from 'fs/promises';
 import path from 'path';
 
 const production = !process.env.ROLLUP_WATCH;
@@ -88,11 +88,12 @@ export default {
 				}
 			}
 		}),
-		Boolean(process.env.BD_PLUGIN_PATH) &&
-			command(`cp --force "${file}" "${process.env.BD_PLUGIN_PATH}"`, {
-				once: false,
-				wait: true
-			})
+		{
+			name: 'copyDistFile',
+			writeBundle: () => Boolean(process.env.BD_PLUGIN_PATH) &&
+				fs.copyFile(file, process.env.BD_PLUGIN_PATH) &&
+				console.log(`Copied dist file to ${process.env.BD_PLUGIN_PATH}`)
+		}
 	],
 	watch: {
 		clearScreen: false

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -1,12 +1,12 @@
 import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import command from 'rollup-plugin-command';
 import { terser } from 'rollup-plugin-terser';
 import replace from '@rollup/plugin-replace';
 import postcss from 'rollup-plugin-postcss';
 import postcssPresetEnv from 'postcss-preset-env';
 import autoPreprocess from 'svelte-preprocess';
+import fs from 'fs/promises';
 import path from 'path';
 
 const production = !process.env.ROLLUP_WATCH;
@@ -100,11 +100,12 @@ export default {
 				'module.exports = vencordMain;': ''
 			}
 		}),
-		Boolean(process.env.VENCORD_PLUGIN_PATH) &&
-			command(`cp --force "${file}" "${process.env.VENCORD_PLUGIN_PATH}"`, {
-				once: false,
-				wait: true
-			})
+		{
+			name: 'copyDistFile',
+			writeBundle: () => Boolean(process.env.VENCORD_PLUGIN_PATH) &&
+				fs.copyFile(file, process.env.VENCORD_PLUGIN_PATH) &&
+				console.log(`Copied dist file to ${process.env.VENCORD_PLUGIN_PATH}`)
+		}
 	],
 	watch: {
 		clearScreen: false

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -213,7 +213,7 @@
 		disableToasts: false,
 		closeWindowOnSend: false,
 		useLeftToolbar: false,
-		hidePackAppendix: false,
+		showPackAppendix: false,
 		disableDownscale: false,
 		disableImportedObfuscation: false,
 		alwaysSendAsLink: false,
@@ -2525,8 +2525,8 @@
 								<div class="preview"
 									style="background-image: { `url(${formatUrl(pack.id, pack.files[0], false, 0)})` }" />
 								<div class="info">
-									<span title="{ settings.hidePackAppendix ? `ID: ${pack.id}` : ''}">{ pack.name }</span>
-									<span>{ pack.count } stickers{ @html settings.hidePackAppendix ? '' : formatPackAppendix(pack.id) }</span>
+									<span title="{ settings.showPackAppendix ? '' : `ID: ${pack.id}`}">{ pack.name }</span>
+									<span>{ pack.count } stickers{ @html settings.showPackAppendix ? formatPackAppendix(pack.id) : '' }</span>
 								</div>
 								<div class="action{ localPacks[pack.id] && (isLocalPackID(pack.id) || localPacks[pack.id].updateUrl) ? ' is-tight' : '' }">
 									<button class="button is-danger"
@@ -2566,8 +2566,8 @@
 									<div class="preview"
 										style="background-image: { `url(${formatUrl(pack.id, pack.files[0], false, 0)})` }" />
 									<div class="info">
-										<span title="{ settings.hidePackAppendix ? `ID: ${pack.id}` : ''}">{ pack.name }</span>
-										<span>{ pack.count } stickers{ @html settings.hidePackAppendix ? '' : formatPackAppendix(pack.id) }</span>
+										<span title="{ settings.showPackAppendix ? '' : `ID: ${pack.id}`}">{ pack.name }</span>
+										<span>{ pack.count } stickers{ @html settings.showPackAppendix ? formatPackAppendix(pack.id) : '' }</span>
 									</div>
 									<div class="action{ localPacks[pack.id] ? ' is-tight' : '' }">
 										{ #if subscribedPacksSimple.includes(pack.id) }
@@ -2711,10 +2711,10 @@
 								<p>
 									<label>
 										<input
-											name="hidePackAppendix"
+											name="showPackAppendix"
 											type="checkbox"
-											bind:checked={ settings.hidePackAppendix } />
-										Hide pack's appendix in packs list (e.g. its numerical ID)
+											bind:checked={ settings.showPackAppendix } />
+										Show pack's appendix in packs list (e.g. its numerical ID)
 									</label>
 								</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -109,7 +109,10 @@
 						type = VENCORD_TOASTS_TYPE[options.type];
 						delete options.type;
 					}
-					if (options.timeout !== undefined) {
+					if (options.timeout === undefined) {
+						// BetterDiscord's default timeout for toasts
+						options.duration = 3000;
+					} else {
 						options.duration = options.timeout;
 						delete options.timeout;
 					}
@@ -1058,7 +1061,7 @@
 			}
 		} catch (error) {
 			console.error(error);
-			toastError(error.toString(), { nolog: true, timeout: 5000 });
+			toastError(error.toString(), { nolog: true, timeout: 6000 });
 		}
 
 		onCooldown = false;
@@ -1802,7 +1805,7 @@
 		try {
 			if (!localPacks[id] || !localPacks[id].updateUrl) return;
 			if (!silent) {
-				toast('Updating pack information\u2026', { nolog: true });
+				toast('Updating pack information\u2026', { nolog: true, timeout: 1500 });
 			}
 
 			// Only pass update URL, the function will determine by itself what to do with it

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -202,6 +202,7 @@
 
 	// For display in info popup only, expandable if required
 	const remotePackTypes = {
+		0: 'Custom JSON',
 		1: 'Chibisafe Albums',
 		2: 'Old Chibisafe / Lolisafe v3 Albums'
 	};
@@ -1751,11 +1752,11 @@
 			if (match.index === 1) {
 				// Basically restores it to its original public album link
 				url = `${match.result[1]}${match.result[2]}/a/${match.result[3]}`;
+				opts.updateUrl = url;
 			}
 
 			opts.id = `${match.result[2]}-${match.result[3]}`;
 			opts.homeUrl = url;
-			opts.updateUrl = url;
 
 			// API will now be always deteremined on-the-fly,
 			// to allow changing this in the future, if required,
@@ -1783,6 +1784,11 @@
 				data = await response.json();
 				opts.remoteType = 2; // assign remote type 2
 			}
+		} else {
+			// Custom JSON
+			const response = await fetch(opts.updateUrl);
+			data = await response.json();
+			opts.remoteType = 0; // assign remote type 0
 		}
 
 		if (!data) {
@@ -1845,6 +1851,17 @@
 	const showPackInfo = id => {
 		if (!localPacks[id]) return;
 
+		let remoteType = 'N/A';
+		if (typeof localPacks[id].remoteType === 'number') {
+			remoteType = `${localPacks[id].remoteType} – ${remotePackTypes[localPacks[id].remoteType] || 'Unknown'}`;
+		} else if (id.startsWith('custom-')) {
+			remoteType = 'Unknown';
+		} else if (id.startsWith('startswith-')) {
+			remoteType = 'LINE';
+		} else if (id.startsWith('emojis-')) {
+			remoteType = 'LINE Emojis';
+		}
+
 		// Formatting is very particular, so we do this the old-fashioned way
 		/* eslint-disable prefer-template */
 		const content = '**ID:**\n\n' +
@@ -1860,10 +1877,7 @@
 			'**Update URL:**\n\n' +
 			('```\n' + (localPacks[id].updateUrl || 'N/A') + '\n```') + '\n\n' +
 			'**Remote Type:**\n\n' +
-			(localPacks[id].remoteType
-				? `${localPacks[id].remoteType} – ${remotePackTypes[localPacks[id].remoteType]}`
-				: 'N/A'
-			);
+			remoteType;
 		/* eslint-enable prefer-template */
 
 		Helper.Alerts.show(

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2528,12 +2528,12 @@
 									<span title="{ settings.hidePackAppendix ? `ID: ${pack.id}` : ''}">{ pack.name }</span>
 									<span>{ pack.count } stickers{ @html settings.hidePackAppendix ? '' : formatPackAppendix(pack.id) }</span>
 								</div>
-								<div class="action{ localPacks[pack.id] && (pack.id.startsWith('custom-') || localPacks[pack.id].updateUrl) ? ' is-tight' : '' }">
+								<div class="action{ localPacks[pack.id] && (isLocalPackID(pack.id) || localPacks[pack.id].updateUrl) ? ' is-tight' : '' }">
 									<button class="button is-danger"
 										on:click="{ () => unsubscribeToPack(pack) }"
 										title="Unsubscribe">Del</button>
 									{ #if localPacks[pack.id] }
-									{ #if pack.id.startsWith('custom-') }
+									{ #if isLocalPackID(pack.id) }
 									<button class="button pack-info"
 										on:click="{ () => showPackInfo(pack.id) }"
 										title="Info">i</button>
@@ -2580,7 +2580,7 @@
 											title="Subscribe">Add</button>
 										{ /if }
 										{ #if localPacks[pack.id] }
-										{ #if pack.id.startsWith('custom-') }
+										{ #if isLocalPackID(pack.id) }
 										<button class="button pack-info"
 											on:click="{ () => showPackInfo(pack.id) }"
 											title="Info">i</button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -807,13 +807,13 @@
 		} else if (pack.startsWith('startswith-')) {
 			/*
 				LINE Store packs
-				292p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker@2x.png;compress=true
-				219p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png;compress=true
-				146p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker.png;compress=true
+				292p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker@2x.png
+				219p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png
+				146p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker.png
 				WARNING: Early packs (can confirm with packs that have their sticker IDs at 4 digits),
 				do not have iPhone variants, so we will stick with Android variants, which are always available.
 			*/
-			const template = 'https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png;compress=true';
+			const template = 'https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png';
 			url = template.replace(/%id%/g, id.split('.')[0]);
 			let append = sending ? '&h=180p' : '&h=100p';
 			if (localPacks[pack].animated) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -216,6 +216,7 @@
 		disableDownscale: false,
 		disableImportedObfuscation: false,
 		alwaysSendAsLink: false,
+		maskStickerLink: false,
 		ctrlInvertSendBehavior: false,
 		ignoreEmbedLinksPermission: false,
 		markAsSpoiler: false,
@@ -1017,8 +1018,9 @@
 				}
 
 				let append = url;
-				if (settings.markAsSpoiler) {
-					append = `||${append}||`;
+
+				if (settings.maskStickerLink) {
+					append = `[sticker](${append})`;
 				}
 
 				Modules.MessageUtils._sendMessage(channelId, {
@@ -2707,7 +2709,7 @@
 											name="disableDownscale"
 											type="checkbox"
 											bind:checked={ settings.disableDownscale } />
-										Disable downscaling of manually imported LINE Store packs
+										Disable downscaling of imported LINE Store packs using <code>images.weserv.nl</code>
 									</label>
 								</p>
 								<p>
@@ -2726,6 +2728,15 @@
 											type="checkbox"
 											bind:checked={ settings.alwaysSendAsLink } />
 										Always send stickers as links instead of uploads
+									</label>
+								</p>
+								<p>
+									<label>
+										<input
+											name="maskStickerLink"
+											type="checkbox"
+											bind:checked={ settings.maskStickerLink } />
+										Mask sticker links with <code>[sticker](url)</code> Markdown
 									</label>
 								</p>
 								<p>
@@ -2752,7 +2763,7 @@
 											name="markAsSpoiler"
 											type="checkbox"
 											bind:checked={ settings.markAsSpoiler } />
-										Mark stickers as spoilers when sending
+										Mark stickers as spoilers when sending (does not work when sending stickers as links)
 									</label>
 								</p>
 								<p>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1878,7 +1878,7 @@
 			'**Home URL:**\n\n' +
 			(localPacks[id].homeUrl || 'N/A') + '\n\n' +
 			'**Update URL:**\n\n' +
-			('```\n' + (localPacks[id].updateUrl || 'N/A') + '\n```') + '\n\n' +
+			'```\n' + (localPacks[id].updateUrl || 'N/A') + '\n```\n\n' +
 			'**Remote Type:**\n\n' +
 			remoteType;
 		/* eslint-enable prefer-template */

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -812,13 +812,13 @@
 		} else if (pack.startsWith('startswith-')) {
 			/*
 				LINE Store packs
-				292p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker@2x.png
-				219p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png
-				146p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker.png
+				292p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker@2x.png;compress=true
+				219p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png;compress=true
+				146p: https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/iPhone/sticker.png;compress=true
 				WARNING: Early packs (can confirm with packs that have their sticker IDs at 4 digits),
 				do not have iPhone variants, so we will stick with Android variants, which are always available.
 			*/
-			const template = 'https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png';
+			const template = 'https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png;compress=true';
 			url = template.replace(/%id%/g, id.split('.')[0]);
 			let append = sending ? '&h=180p' : '&h=100p';
 			if (localPacks[pack].animated) {
@@ -1856,9 +1856,7 @@
 
 		let remoteType = 'N/A';
 		if (typeof localPacks[id].remoteType === 'number') {
-			remoteType = `${localPacks[id].remoteType} – ${remotePackTypes[localPacks[id].remoteType] || 'Unknown'}`;
-		} else if (id.startsWith('custom-')) {
-			remoteType = 'Unknown';
+			remoteType = `${localPacks[id].remoteType} – ${remotePackTypes[localPacks[id].remoteType] || 'N/A'}`;
 		} else if (id.startsWith('startswith-')) {
 			remoteType = 'LINE';
 		} else if (id.startsWith('emojis-')) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2724,7 +2724,7 @@
 											name="disableDownscale"
 											type="checkbox"
 											bind:checked={ settings.disableDownscale } />
-										Disable downscaling of imported LINE Store packs using <code>images.weserv.nl</code>
+										Disable downscaling of imported LINE packs using <code>images.weserv.nl</code> (this service is known to be blocked by Discord if sending as links)
 									</label>
 								</p>
 								<p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,11 +3235,6 @@ rimraf@^2.5.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-plugin-command@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-command/-/rollup-plugin-command-1.1.3.tgz#c42ac0a6313560f2184e9c64c431f0a639373ffe"
-  integrity sha512-9nIcP5mgVYWGU7x/6ufTgtqI4vl5vvsYs6fTTil91NX53EIPcim42FXmq1TPdZRFJbUM1ikrg05clahPxObL1g==
-
 rollup-plugin-license@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-license/-/rollup-plugin-license-2.8.1.tgz#3709ef8b59675e0162a27ea7bba10ee523f8289e"


### PR DESCRIPTION
Fix custom JSON packs.
Yet another oopsie from the recent PRs. All good this time, promise.

---
New option: Mask sticker links with markdown.

![screenshot](https://i.fiery.me/iALV.png)

![screenshot](https://i.fiery.me/svwa.png)
In practice, the message will only show "sticker" in blue (clickable link), instead of the whole long urls, for a brief moment. When Discord has the image ready, the text itself will disappear and instead only show the image embed, like the following:
![screenshot](https://i.fiery.me/Knb0.png)
Well, Discord was already doing that even if you send lone image url as-is, but there will be less whiplash from long urls with this I guess.