### PR TITLE
Pr 3.2.18 restore sending as uploads, and a few other things

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/rollup-bd.config.js
+++ b/rollup-bd.config.js
@@ -12,7 +12,13 @@ import path from 'path';
 
 const production = !process.env.ROLLUP_WATCH;
 const file = path.resolve(__dirname, production ? 'dist' : 'dist-dev', 'magane.plugin.js');
-const meta = path.resolve(__dirname, 'src/bd-meta.txt');
+const meta = path.resolve(__dirname, 'src/meta.txt');
+const metadata = {
+	name: 'MaganeBD',
+	displayName: 'MaganeBD',
+	description: 'Bringing LINE stickers to Discord in a chaotic way. BetterDiscord edition.',
+	updateUrl: 'https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.plugin.js'
+};
 
 export default {
 	input: 'src/bd-main.js',
@@ -85,7 +91,8 @@ export default {
 				content: {
 					file: meta,
 					encoding: 'utf-8'
-				}
+				},
+				data() { return metadata; }
 			}
 		}),
 		{

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -1,6 +1,7 @@
 import svelte from 'rollup-plugin-svelte';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import license from 'rollup-plugin-license';
 import { terser } from 'rollup-plugin-terser';
 import replace from '@rollup/plugin-replace';
 import postcss from 'rollup-plugin-postcss';
@@ -11,6 +12,13 @@ import path from 'path';
 
 const production = !process.env.ROLLUP_WATCH;
 const file = path.resolve(__dirname, production ? 'dist' : 'dist-dev', 'magane.vencord.js');
+const meta = path.resolve(__dirname, 'src/meta.txt');
+const metadata = {
+	name: 'MaganeVencord',
+	displayName: 'MaganeVencord',
+	description: 'Bringing LINE stickers to Discord in a chaotic way. Vencord edition.',
+	updateUrl: 'https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.vencord.js'
+};
 
 export default {
 	input: 'src/vencord-main.js',
@@ -98,6 +106,16 @@ export default {
 				// This is so hacky, lmao
 				'var vencordMain = definePlugin({': 'export default definePlugin({',
 				'module.exports = vencordMain;': ''
+			}
+		}),
+		license({
+			banner: {
+				commentStyle: 'regular',
+				content: {
+					file: meta,
+					encoding: 'utf-8'
+				},
+				data() { return metadata; }
 			}
 		}),
 		{

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -497,12 +497,9 @@
 		// Permissions
 		Modules.DiscordConstants = Helper.findByProps('Permissions', 'ActivityTypes', 'StatusTypes');
 		Modules.DiscordPermissions = Helper.find(m => m.ADD_REACTIONS, { searchExports: true });
-		try {
-			const module = Helper.find(m => m.Permissions && m.Permissions.ADMINISTRATOR, { searchExports: true });
-			Modules.PermissionsBits = module.Permissions;
-		} catch {
-			Modules.PermissionsBits = Helper.find(m => typeof m.ADMINISTRATOR === 'bigint', { searchExports: true });
-		}
+		const module = Helper.find(m => m.Permissions && typeof m.Permissions.ADMINISTRATOR === 'bigint',
+			{ searchExports: true });
+		Modules.PermissionsBits = module.Permissions;
 		Modules.Permissions = Helper.findByProps('computePermissions');
 		Modules.UserStore = Helper.findByProps('getCurrentUser', 'getUser');
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -932,16 +932,16 @@
 				channelId = Modules.SelectedChannelStore.getChannelId();
 			}
 
-			let channel;
-			if (Modules.ChannelStore) {
-				channel = Modules.ChannelStore.getChannel(channelId);
-			}
-
 			// Magane will also appear in Create Thread screen,
 			// but at that point the thread has not yet been made, and thus will not have ID.
 			if (!channelId) {
 				onCooldown = false;
 				return toastError('Unable to determine channel ID. Is this a pending Thread creation?');
+			}
+
+			let channel;
+			if (Modules.ChannelStore) {
+				channel = Modules.ChannelStore.getChannel(channelId);
 			}
 
 			if (!hasPermission('SEND_MESSAGES', channelId)) {

--- a/src/meta.txt
+++ b/src/meta.txt
@@ -1,6 +1,6 @@
-@name MaganeBD
-@displayName MaganeBD
-@description Bringing LINE stickers to Discord in a chaotic way. BetterDiscord-plugin edition.
+@name <%= data.name %>
+@displayName <%= data.displayName %>
+@description <%= data.description %>
 @author Kana, Bobby
 @authorId 176200089226706944
 @authorLink https://github.com/Pitu
@@ -8,7 +8,7 @@
 @version <%= pkg.version %>
 @invite 5g6vgwn
 @source https://github.com/Pitu/Magane
-@updateUrl https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.plugin.js
+@updateUrl <%= data.updateUrl %>
 @website https://magane.moe
 @donate https://github.com/sponsors/Pitu
 @patreon https://patreon.com/pitu

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -674,3 +674,13 @@ div#maganeButton {
 		margin-right: 2px;
 	}
 }
+
+/* Visually hide Magane button in certain scenarios */
+
+div[class^="submitContainer_"] div#maganeButton { /* create thread */
+	display: none;
+}
+
+div[data-list-item-id^="forum-channel-list-"] div#maganeButton { /* create forum post */
+	display: none;
+}


### PR DESCRIPTION
- Sending stickers as uploads now work the same way they used to.
- Improve logic of determining selected textarea, channel, and all that jazz.
- Magane button no longer appearing in textareas of Create Thread and Create Forum Post forms.  
They'd never work there to begin with, since such textareas would've had no active "channel" until they had been created.
- Also add metadata comments for Vencord plugin file. Wanted to expand the update checker for Vencord as well, but it seems like it'll require a bit more experimenting but I'm out of time. I'll probably get back to it at another day so I'm finalizing this PR already.