### PR TITLE
Pr 3.2.22 fix CSP policies for vencord again, and implement update checker for vencord

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By injecting the script into Discord it will automatically pull a curated list o
 
 You can!
 
-Currently the best way to get this up and running is by using [BetterDiscord](https://github.com/rauenzi/BetterDiscordApp/releases), but we also have experimental support for [Vencord](https://vencord.dev/).
+Currently the best way to get this up and running is by using [BetterDiscord](https://github.com/rauenzi/BetterDiscordApp/releases) or [Vencord](https://vencord.dev/).
 
 #### BetterDiscord
 
@@ -32,11 +32,7 @@ Currently the best way to get this up and running is by using [BetterDiscord](ht
 
 #### Vencord
 
-> This is for the more advanced users.  
-> Be advised that Magane's **update checker is not available** on Vencord.  
-> You must manually consult this repo to check for updates! Or just check back whenever it breaks due to Discord's updates...
-
-1. Grab Magane's Vencord plugin directory from `dist/maganevencord`.
+1. Grab Magane's Vencord plugin directory from [https://github.com/Pitu/Magane/tree/master/dist/maganevencord](https://github.com/Pitu/Magane/tree/master/dist/maganevencord).
 2. Install Vencord from source. Follow its installation guide at [https://docs.vencord.dev/installing/](https://docs.vencord.dev/installing/).
 3. In Vencord git directory, navigate to `src`, then create `userplugins` directory (e.g., `/path/to/vencord/src/userplugins`).
 4. Place Magane's plugin directory into it (e.g, `.../userplugins/maganevencord`). It must contain both `index.ts` and `native.ts`.
@@ -46,7 +42,7 @@ For those that use **Vesktop**, please see below.
 7. Restart your Discord/Vesktop.
 8. Activate Magane from Discord's **User Settings > Vencord > Plugins**.
 
-> Due to Vencord enforcing CSP policies, if you need to import packs from third-party Chibisafe hosts, you have to add the domains to `native.ts` file.  
+> Due to Vencord enforcing CSP, if you need to import packs from third-party Chibisafe hosts, you have to add the domains to `native.ts` file.  
 > Restart your Discord/Vesktop after making any changes to it.
 
 #### Vesktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.21",
+  "version": "3.2.22",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/rollup-bd.config.js
+++ b/rollup-bd.config.js
@@ -15,8 +15,12 @@ const metadata = {
 	name: 'MaganeBD',
 	displayName: 'MaganeBD',
 	description: 'Bringing LINE stickers to Discord in a chaotic way. BetterDiscord edition.',
+	version: require('./package.json').version,
 	updateUrl: 'https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.plugin.js'
 };
+
+const PACKAGE_URL = 'https://raw.githubusercontent.com/Pitu/Magane/refs/heads/master/package.json';
+const GITHUB_URL = 'https://github.com/Pitu/Magane';
 
 const meta = path.resolve(__dirname, 'src/meta.txt');
 
@@ -36,7 +40,7 @@ export default {
 	},
 	plugins: [
 		!production && {
-			name: 'watch-extras',
+			name: 'watchExtras',
 			buildStart() {
 				this.addWatchFile(meta);
 			}
@@ -44,7 +48,14 @@ export default {
 		svelte({
 			dev: !production,
 			emitCss: true,
-			preprocess: autoPreprocess(),
+			preprocess: autoPreprocess({
+				replace: [
+					['const VERSION = null;', `const VERSION = '${metadata.version}';`],
+					['const UPDATE_URL = null;', `const UPDATE_URL = '${metadata.updateUrl}';`],
+					['const PACKAGE_URL = null;', `const PACKAGE_URL = '${PACKAGE_URL}';`],
+					['const GITHUB_URL = null', `const GITHUB_URL = '${GITHUB_URL}';`]
+				]
+			}),
 			onwarn: (warning, handler) => {
 				if (warning.code === 'a11y-click-events-have-key-events') return;
 				handler(warning);

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -128,7 +128,7 @@ export default {
 		}),
 		{
 			name: 'vencordImports',
-			generateBundle: async (options, bundle, isWrite) => {
+			generateBundle: (options, bundle, isWrite) => {
 				bundle[outputFileName].code = bundle[outputFileName].code.replace(
 					/(['"]use strict['"];)/,
 					'$1\n\n' +

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1389,7 +1389,7 @@
 			: MountType.LEGACY;
 
 		// Build script for other mods should probably find-replace the following if necessary.
-		mountType = mountType; // Svelte builds this line into: $$invalidate(0, mountType)
+		mountType = mountType;
 
 		switch (mountType) {
 			case MountType.BETTERDISCORD:

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,14 +19,10 @@
 	};
 	let mountType = null;
 
-	/*
-		Built-in update checker is not available outside of BetterDiscord.
-		Find-replacing these is not possible due to Svelte directly injecting string constants
-		into any functions that use them when building in production mode.
-	*/
-	const bdPluginName = 'MaganeBD';
-	const githubUrl = 'https://github.com/Pitu/Magane/commits/master';
-	const updateUrl = 'https://raw.githubusercontent.com/Pitu/Magane/master/dist/magane.plugin.js';
+	const VERSION = null;
+	const UPDATE_URL = null;
+	const PACKAGE_URL = null;
+	const GITHUB_URL = null;
 
 	// APIs
 	const Modules = {};
@@ -130,38 +126,23 @@
 				return MOCK_API.TOASTS_SHOW(...args);
 			}
 		},
-		Plugins: {
-			isEnabled(...args) {
-				switch (mountType) {
-					case MountType.BETTERDISCORD:
-						return BdApi.Plugins.isEnabled(...args);
-					case MountType.VENCORD:
-						return null; // TODO Vencord
-					default:
-						return MOCK_API.PLUGINS_ISENABLED(...args);
-				}
-			},
-			getVersion(...args) {
-				switch (mountType) {
-					case MountType.BETTERDISCORD:
-						return BdApi.Plugins.get(...args).version;
-					case MountType.VENCORD:
-						return null; // TODO Vencord
-					default:
-						return MOCK_API.PLUGINS_GETVERSION(...args);
-				}
-			}
-		},
 		UI: {
 			showNotice(...args) {
-				switch (mountType) {
-					case MountType.BETTERDISCORD:
-						return BdApi.UI.showNotice(...args);
-					case MountType.VENCORD:
-						return null; // TODO Vencord
-					default:
-						return MOCK_API.UI_SHOWNOTICE(...args);
+				if (mountType === MountType.BETTERDISCORD) {
+					return BdApi.UI.showNotice(...args);
+				} else if (mountType === MountType.VENCORD) {
+					let buttonText = 'OK';
+					let onOkClick = () => VencordApi.Notices.popNotice();
+
+					if (Array.isArray(args[1]?.buttons) && args[1].buttons.length) {
+						buttonText = args[1].buttons[0].label;
+						onOkClick = args[1].buttons[0].onClick;
+					}
+
+					return VencordApi.Notices.showNotice(args[0], buttonText, onOkClick);
 				}
+
+				return MOCK_API.UI_SHOWNOTICE(...args);
 			}
 		}
 	};
@@ -549,45 +530,39 @@
 	};
 
 	const checkUpdate = async (manual = false) => {
-		if (mountType !== MountType.BETTERDISCORD) {
-			return toastWarn('Sorry, update checker is only available when running on BetterDiscord.');
+		if (!VERSION || !UPDATE_URL || !PACKAGE_URL) {
+			return toastWarn('Sorry, update checker is not available for this release.');
 		}
 
-		// Check if hard-coded plugin name is enabled, sanity-check to ensure the running script is it
-		if (!Helper.Plugins.isEnabled(bdPluginName)) {
-			return toastWarn(`Update check skipped, is this plugin not named ${bdPluginName}?`);
-		}
-
-		const currentVersion = Helper.Plugins.getVersion(bdPluginName);
-
-		log(`Fetching remote dist file from: ${updateUrl}`);
+		log(`Fetching remote dist file from: ${PACKAGE_URL}`);
 		if (manual) toast('Checking for updates\u2026', { nolog: true });
 
-		await fetch(updateUrl, { cache: 'no-cache' }).then(async response => {
+		await fetch(PACKAGE_URL, { cache: 'no-cache' }).then(async response => {
 			log('Remote dist file fetched.');
 
-			const data = await response.text();
-			const match = data.match(/^ \* @version ([a-zA-Z0-9.-]+)$/m);
-			const remoteVersion = match?.[1];
+			const data = await response.json();
+			if (data.version) {
+				if (SemverGt(data.version, VERSION)) {
+					log(`Update found: ${data.version} > ${VERSION}.`);
 
-			if (remoteVersion) {
-				if (SemverGt(remoteVersion, currentVersion)) {
-					log(`Update found: ${remoteVersion} > ${currentVersion}.`);
+					const buttons = [{
+						label: 'Download',
+						onClick: () => window.open(UPDATE_URL, { target: '_blank' })
+					}];
 
-					Helper.UI.showNotice(`Magane v${currentVersion} found an update: v${remoteVersion}. Please download the update manually.`, {
-						buttons: [
-							{
-								label: 'GitHub',
-								onClick: () => window.open(githubUrl, { target: '_blank' })
-							},
-							{
-								label: 'Download',
-								onClick: () => window.open(updateUrl, { target: '_blank' })
-							}
-						]
-					});
+					if (GITHUB_URL) {
+						buttons.unshift({
+							label: 'GitHub',
+							onClick: () => window.open(GITHUB_URL, { target: '_blank' })
+						});
+					}
+
+					Helper.UI.showNotice(
+						`Magane v${VERSION} found an update: v${data.version}. Please download the update manually.`,
+						{ buttons }
+					);
 				} else {
-					log(`No updates found: ${remoteVersion} <= ${currentVersion}.`);
+					log(`No updates found: ${data.version} <= ${VERSION}.`);
 					if (manual) toast('No updates found.', { nolog: true });
 				}
 			} else {
@@ -1451,8 +1426,7 @@
 
 		log(`Time taken: ${(Date.now() - startTime) / 1000}s.`);
 
-		// Only check for updates if running on BetterDiscord
-		if (!settings.disableUpdateCheck && mountType === MountType.BETTERDISCORD) {
+		if (!settings.disableUpdateCheck) {
 			await checkUpdate();
 		}
 	});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -358,8 +358,8 @@
 
 		for (const textArea of textAreas) {
 			// Assign ephemeral ID to the textArea element
-			if (!textArea._maganeID) {
-				textArea._maganeID = Date.now();
+			if (!textArea.dataset.magane_id) {
+				textArea.dataset.magane_id = Date.now();
 			}
 
 			let valid = false;
@@ -378,24 +378,24 @@
 			}
 
 			if (valid) {
-				log(`Textarea #${textArea._maganeID}: still attached`);
+				log(`Textarea #${textArea.dataset.magane_id}: still attached`);
 				continue;
 			}
 
 			// Mount button component attached to the textArea
 			const component = mountButtonComponent(textArea);
 			if (component) {
-				log(`Textarea #${textArea._maganeID}: attached`);
+				log(`Textarea #${textArea.dataset.magane_id}: attached`);
 				resizeObserver.observe(textArea);
 				componentsNew.push(component);
 			} else {
-				log(`Textarea #${textArea._maganeID}: failed to attach`);
+				log(`Textarea #${textArea.dataset.magane_id}: failed to attach`);
 			}
 		}
 
 		// Loop through and destroy outdated components
 		for (const component of componentsOld) {
-			log(`Textarea #${component.textArea._maganeID}: outdated, destroying\u2026`);
+			log(`Textarea #${component.textArea.dataset.magane_id}: outdated, destroying\u2026`);
 			// Force-close sticker window if an active component is outdated
 			if (activeComponent === component) {
 				// eslint-disable-next-line no-use-before-define
@@ -1524,10 +1524,9 @@
 
 		// If unable to choose a component, return early
 		if (!toggledComponent) return;
-		if (!document.body.contains(toggledComponent.textArea)) return;
 
 		const active = typeof forceState === 'undefined' ? !stickerWindowActive : forceState;
-		if (active) {
+		if (active && document.body.contains(toggledComponent.textArea)) {
 			// Re-position magane's sticker window
 			updateStickerWindowPosition(toggledComponent);
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2694,7 +2694,7 @@
 											name="disableDownscale"
 											type="checkbox"
 											bind:checked={ settings.disableDownscale } />
-										Disable downscaling of imported LINE packs using <code>wsrv.nl</code> (this service is known to be blocked by Discord if sending as links)
+										Disable downscaling of imported LINE packs using <code>wsrv.nl</code>
 									</label>
 								</p>
 								<p>

--- a/src/meta.txt
+++ b/src/meta.txt
@@ -5,7 +5,7 @@
 @authorId 176200089226706944
 @authorLink https://github.com/Pitu
 @license MIT - https://opensource.org/licenses/MIT
-@version <%= pkg.version %>
+@version <%= data.version %>
 @invite 5g6vgwn
 @source https://github.com/Pitu/Magane
 @updateUrl <%= data.updateUrl %>

--- a/src/vencord-main.js
+++ b/src/vencord-main.js
@@ -1,10 +1,8 @@
 /* global definePlugin */
 const App = require('./App.svelte');
 
-const pluginName = 'MaganeVencord';
-
-export default definePlugin({
-	name: pluginName,
+module.exports = definePlugin({
+	name: 'MaganeVencord',
 	authors: [
 		{
 			id: 176200089226706944n,
@@ -24,7 +22,7 @@ export default definePlugin({
 	start() {
 		for (const id of Object.keys(window.MAGANE_STYLES)) {
 			const style = document.createElement('style');
-			style.id = `${pluginName}-${id}`;
+			style.id = `MaganeVencord-${id}`;
 			style.innerText = window.MAGANE_STYLES[id];
 			document.head.appendChild(style);
 		}
@@ -47,7 +45,7 @@ export default definePlugin({
 			this.container.remove();
 		}
 		for (const id of Object.keys(window.MAGANE_STYLES)) {
-			const _style = document.head.getElementById(`${pluginName}-${id}`);
+			const _style = document.head.getElementById(`MaganeVencord-${id}`);
 			if (_style) {
 				_style.remove();
 			}

--- a/src/vencord-native.ts
+++ b/src/vencord-native.ts
@@ -1,14 +1,13 @@
-import { CspPolicies, MediaSrc } from '@main/csp';
+import { CspPolicies, ImageSrc } from '@main/csp';
 
 // Magane's built-in packs
-CspPolicies['magane.moe'] = MediaSrc;
+CspPolicies['magane.moe'] = ImageSrc;
 // Chibisafe
-CspPolicies['chibisafe.moe'] = MediaSrc;
+CspPolicies['chibisafe.moe'] = ImageSrc;
 // LINE Store
-CspPolicies['stickershop.line-scdn.net'] = MediaSrc;
+CspPolicies['stickershop.line-scdn.net'] = ImageSrc;
 // Image resize service for imported LINE Store packs
-CspPolicies['wsrv.nl'] = MediaSrc;
+CspPolicies['wsrv.nl'] = ImageSrc;
 
 // If you need to import packs from third-party Chibisafe-based hosts, add the domains here.
-// CspPolicies['example.com'] = MediaSrc;
-// CspPolicies['example.com'] = MediaSrc;
+// CspPolicies['example.com'] = ImageSrc;


### PR DESCRIPTION
Vencord changed the constants 10h ago, lmao
https://github.com/Vendicated/Vencord/commit/ed5ed4b80a7b3a50858eefef083b385449147486#diff-556ddcad7cc2db948ab2668ee9611f8d876722173c711e810c5a28e9abb7fc4e

While I was at it, I looked into how the update checker was implemented once again, and figured I could streamline it further to support other platforms, in this case Vencord/Vesktop.

Also fixed an ancient silly bug where Magane won't auto-close its window when switching channel. I kept on forgetting if it was intended or not, and just earlier realized it was not intended (it'd always alert you about having to re-open the window anyway).