### PR TITLE
Pr 3.2.24

### DIFF
--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -153,9 +153,11 @@ export default {
 				await fs.copyFile(outputFile, indexDest);
 				console.log(`Copied index file to ${indexDest}`);
 
-				const nativeDest = path.resolve(process.env.VENCORD_PLUGIN_PATH, 'native.ts');
-				await fs.copyFile(nativeFile, nativeDest);
-				console.log(`Copied native file to ${nativeDest}`);
+				if (!process.env.VENCORD_SKIP_NATIVE) {
+					const nativeDest = path.resolve(process.env.VENCORD_PLUGIN_PATH, 'native.ts');
+					await fs.copyFile(nativeFile, nativeDest);
+					console.log(`Copied native file to ${nativeDest}`);
+				}
 			}
 		}
 	],

--- a/rollup-vencord.config.js
+++ b/rollup-vencord.config.js
@@ -135,7 +135,10 @@ export default {
 					'import definePlugin from "@utils/types";\n' +
 					'import { findByPropsLazy, findLazy } from "@webpack";\n' +
 					'import { Alerts, Toasts } from "@webpack/common";\n' +
-					'import { Notices } from "@api/index";'
+					'import { Notices } from "@api/index";\n' +
+					'import { APNG } from "@utils/apng-canvas";\n' +
+					'import { ApngBlendOp, ApngDisposeOp } from "@utils/dependencies";\n' +
+					'import { applyPalette, GIFEncoder, quantize } from "gifenc";'
 				);
 			}
 		},

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -859,6 +859,11 @@
 				url = id;
 			}
 
+			// Don't include filename overrides in the final URL
+			if (url.includes('#')) {
+				url = url.substring(0, url.indexOf('#'));
+			}
+
 			// If not sending, try thumbsTemplate if available, otherwise fallback to template
 			const template = sending
 				? localPacks[pack].template
@@ -970,7 +975,17 @@
 				const response = await fetch(url, { cache: 'force-cache' });
 				const blob = await response.blob();
 
-				let filename = id.substring(id.lastIndexOf('/') + 1).split('?')[0];
+				let filename = id;
+
+				if (pack.startsWith('custom-')) {
+					if (id.includes('#')) {
+						// Allow overriding filenames, for URLs that don't have extensions.
+						// e.g. https://example.com/path/to/image#custom_name.jpg
+						filename = id.substring(id.indexOf('#') + 1);
+					} else {
+						filename = id.substring(id.lastIndexOf('/') + 1).split('?')[0];
+					}
+				}
 
 				if (typeof pack === 'string') {
 					if (localPacks[pack].animated && (pack.startsWith('startswith-') || pack.startsWith('emojis-'))) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -326,7 +326,7 @@
 		const props = buttonsContainer.getBoundingClientRect();
 
 		coords.wbottom = (base.clientHeight - props.top) + 8;
-		coords.wright = (base.clientWidth - props.right) - 6;
+		coords.wright = (base.clientWidth - props.right) - 12;
 
 		if (mountType === MountType.LEGACY) {
 			const baseProps = base.getBoundingClientRect();
@@ -1523,7 +1523,7 @@
 			const { x, y, width, height } = stickerWindow.getBoundingClientRect();
 			if (e.target) {
 				if (activeComponent?.element.contains(e.target)) return;
-				const visibleModals = document.querySelectorAll('[class^="layerContainer-"]');
+				const visibleModals = document.querySelectorAll('[class*="layerContainer_"]');
 				if (visibleModals.length && Array.from(visibleModals).some(m => m.contains(e.target))) return;
 			}
 			if (!((e.clientX <= x + width && e.clientX >= x) &&

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2224,6 +2224,8 @@
 		// Reset selected files in the hidden input
 		event.target.value = '';
 
+		if (!results.length) return false;
+
 		const fileNames = results.map(result => result.name);
 
 		/* eslint-disable-next-line prefer-template */

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -797,12 +797,17 @@
 			*/
 			const template = 'https://stickershop.line-scdn.net/stickershop/v1/sticker/%id%/android/sticker.png;compress=true';
 			url = template.replace(/%id%/g, id.split('.')[0]);
+
 			let append = sending ? '&h=180p' : '&h=100p';
+
 			if (localPacks[pack].animated) {
 				url = url.replace(/sticker(@2x)?\.png/, 'sticker_animation$1.png');
 				// In case one day wsrv.nl starts properly supporting APNGs -> GIFs
 				append += '&output=gif';
+			} else {
+				append += '&af&output=png';
 			}
+
 			if (!settings.disableDownscale) {
 				// Downsizing with wsrv.nl to stay consistent with Magane's built-in packs
 				url = `https://wsrv.nl/?url=${encodeURIComponent(url)}${append}`;
@@ -818,13 +823,20 @@
 				(Android variant of emojis only go up to 154p).
 			*/
 			const template = 'https://stickershop.line-scdn.net/sticonshop/v1/sticon/%pack%/android/%id%.png';
-			url = template.replace(/%pack%/g, pack.split('-')[1]).replace(/%id%/g, id.split('.')[0]);
+			url = template
+				.replace(/%pack%/g, pack.split('-')[1])
+				.replace(/%id%/g, id.split('.')[0]);
+
 			let append = sending ? '' : '&h=100p';
+
 			if (localPacks[pack].animated) {
 				url = url.replace(/\.png/, '_animation.png');
 				// In case one day wsrv.nl starts properly supporting APNGs -> GIFs
 				append += '&output=gif';
+			} else {
+				append += '&af&output=png';
 			}
+
 			if (!settings.disableDownscale) {
 				// Downsizing with wsrv.nl to stay consistent with Magane's built-in packs
 				url = `https://wsrv.nl/?url=${encodeURIComponent(url)}${append}`;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1370,8 +1370,8 @@
 	};
 
 	const appendPack = (...args) => {
-		let { name, firstid, count, animated } = parseFunctionArgs(args,
-			['name', 'firstid', 'count', 'animated'], 3);
+		let { name, firstid, count, animated, homeUrl } = parseFunctionArgs(args,
+			['name', 'firstid', 'count', 'animated', 'homeUrl'], 3);
 
 		firstid = Number(firstid);
 		if (isNaN(firstid) || !isFinite(firstid) || firstid < 0) {
@@ -1390,13 +1390,14 @@
 			count,
 			id: mid,
 			animated,
-			files
+			files,
+			homeUrl
 		});
 	};
 
 	const appendEmojisPack = (...args) => {
-		let { name, id, count, animated } = parseFunctionArgs(args,
-			['name', 'id', 'count', 'animated'], 3);
+		let { name, id, count, animated, homeUrl } = parseFunctionArgs(args,
+			['name', 'id', 'count', 'animated', 'homeUrl'], 3);
 
 		count = Math.max(Math.min(Number(count), 200), 0) || 0;
 		const mid = `emojis-${id}`;
@@ -1410,7 +1411,8 @@
 			count,
 			id: mid,
 			animated,
-			files
+			files,
+			homeUrl
 		});
 	};
 
@@ -2114,7 +2116,8 @@
 							name: props.title,
 							id: props.id,
 							count: props.len,
-							animated: Boolean(props.hasAnimation)
+							animated: Boolean(props.hasAnimation),
+							homeUrl: url
 						});
 					} else {
 						// LINE Stickers work with either its full URL or just its ID
@@ -2126,7 +2129,8 @@
 							name: props.title,
 							firstid: props.first,
 							count: props.len,
-							animated: Boolean(props.hasAnimation)
+							animated: Boolean(props.hasAnimation),
+							homeUrl: url
 						});
 					}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -301,7 +301,7 @@
 			const success = await grabPacks(true);
 
 			if (success) {
-				toastSuccess('Magane is now ready!', { timeout: 1000, force: true });
+				toastSuccess('Magane is now ready!', { force: true });
 			}
 			forceHideMagane = false;
 		});
@@ -582,7 +582,7 @@
 				} else {
 					log(`No updates found: ${data.version} <= ${VERSION}.`);
 					if (manual) {
-						toast('No updates found.', { nolog: true, timeout: 1000, force: true });
+						toast('No updates found.', { nolog: true, force: true });
 					}
 				}
 			} else {
@@ -1176,11 +1176,11 @@
 		}
 
 		if (dirty) {
-			toastInfo('Found packs/stickers to migrate, migrating now...');
+			toastInfo('Found packs/stickers to migrate, migrating now...', { force: true });
 			saveToLocalStorage('magane.favorites', favorites);
 			saveToLocalStorage('magane.subscribed', subscribed);
 			await grabPacks(true);
-			toastSuccess('Migration successful.');
+			toastSuccess('Migration successful.', { force: true });
 		}
 	};
 
@@ -1420,7 +1420,7 @@
 		const startTime = Date.now();
 
 		try {
-			toast('Loading Magane\u2026', { timeout: 1000 });
+			toast('Loading Magane\u2026', { timeout: 1000, force: true });
 
 			// Background tasks
 			initModules();
@@ -1431,7 +1431,7 @@
 			await migrateStringPackIds();
 
 			if (success) {
-				toastSuccess('Magane is now ready!', { timeout: 1000, force: true });
+				toastSuccess('Magane is now ready!', { force: true });
 			}
 
 			// Init ResizeObserver
@@ -1606,7 +1606,7 @@
 			const _name = localPacks[id].name;
 			const deleted = deletePack(id);
 			if (deleted) {
-				toastSuccess(`Removed pack ${_name}.`, { nolog: true });
+				toastSuccess(`Removed pack ${_name}.`, { nolog: true, force: true });
 			}
 		} catch (error) {
 			console.error(error);
@@ -1774,7 +1774,7 @@
 		try {
 			if (!localPacks[id] || !localPacks[id].updateUrl) return;
 			if (!silent) {
-				toast('Updating pack information\u2026', { nolog: true, timeout: 500 });
+				toast('Updating pack information\u2026', { nolog: true, timeout: 1000, force: true });
 			}
 
 			// Only pass update URL, the function will determine by itself what to do with it
@@ -1811,7 +1811,7 @@
 			}
 
 			if (!silent) {
-				toastSuccess(`Updated pack ${stored.pack.name}.`, { nolog: true });
+				toastSuccess(`Updated pack ${stored.pack.name}.`, { nolog: true, timeout: 1000, force: true });
 			}
 			return stored;
 		} catch (error) {
@@ -1882,7 +1882,7 @@
 
 		/* eslint-disable-next-line prefer-template */
 		assertImportPacksConsent('URLs:\n\n```\n' + linePackUrls.join('\n') + '\n```', async () => {
-			toast('Importing packs\u2026', { nolog: true, timeout: 500 });
+			toast('Importing packs\u2026', { nolog: true, timeout: 500, force: true });
 			const failed = [];
 			for (const url of linePackUrls) {
 				try {
@@ -1914,7 +1914,7 @@
 							animated: props.hasAnimation
 						});
 					}
-					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true });
+					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true, timeout: 1000, force: true });
 				} catch (error) {
 					console.error(error);
 					toastError(error.toString(), { nolog: true });
@@ -1942,14 +1942,14 @@
 
 		/* eslint-disable-next-line prefer-template */
 		assertImportPacksConsent('URLs:\n\n```\n' + remotePackUrls.join('\n') + '\n```', async () => {
-			toast('Importing packs\u2026', { nolog: true, timeout: 500 });
+			toast('Importing packs\u2026', { nolog: true, timeout: 500, force: true });
 			const failed = [];
 			for (const url of remotePackUrls) {
 				try {
 					const pack = await fetchRemotePack(url);
 					pack.id = `custom-${pack.id}`;
 					const stored = _appendPack(pack.id, pack);
-					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true });
+					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true, timeout: 1000, force: true });
 				} catch (error) {
 					console.error(error);
 					toastError(error.toString(), { nolog: true });
@@ -1972,7 +1972,7 @@
 
 		const results = [];
 
-		toast(`Reading ${files.length} file${files.length === 1 ? '' : 's'}\u2026`);
+		toast(`Reading ${files.length} file${files.length === 1 ? '' : 's'}\u2026`, { timeout: 500, force: true });
 		for (const file of files) {
 			await new Promise((resolve, reject) => {
 				const reader = new FileReader();
@@ -2006,7 +2006,7 @@
 					const pack = await processRemotePack(result.data);
 					pack.id = `custom-${pack.id}`;
 					const stored = _appendPack(pack.id, pack);
-					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true });
+					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true, timeout: 1000, force: true });
 				} catch (error) {
 					console.error(error);
 					toastError(error.toString(), { nolog: true });
@@ -2045,11 +2045,11 @@
 				onConfirm: async () => {
 					try {
 						for (let i = 0; i < packs.length; i++) {
-							toast(`Updating pack ${i + 1} out of ${packs.length}\u2026`, { nolog: true, timeout: 500 });
+							toast(`Updating pack ${i + 1} out of ${packs.length}\u2026`, { nolog: true, timeout: 500, force: true });
 							const stored = await updateRemotePack(packs[i], true);
 							if (!stored) break;
 						}
-						toastSuccess('Updates completed.', { nolog: true });
+						toastSuccess('Updates completed.', { nolog: true, force: true });
 					} catch (ex) {
 						toastWarn('Updates cancelled due to unexpected errors.', { nolog: true });
 						// Do nothing
@@ -2113,9 +2113,9 @@
 		if (count === 0) {
 			stickersStats = [];
 			saveToLocalStorage('magane.stats', stickersStats);
-			toastSuccess('Settings saved, and stickers usage cleared!', { nolog: true });
+			toastSuccess('Settings saved, and stickers usage cleared!', { nolog: true, force: true });
 		} else {
-			toastSuccess('Settings saved!', { nolog: true });
+			toastSuccess('Settings saved!', { nolog: true, force: true });
 		}
 
 		// Refresh UI
@@ -2200,7 +2200,7 @@
 			log(`settings['hotkey'] = ${settings.hotkey}`);
 
 			saveToLocalStorage('magane.settings', settings);
-			toastSuccess(hotkey ? 'Hotkey saved.' : 'Hotkey cleared.', { nolog: true });
+			toastSuccess(hotkey ? 'Hotkey saved.' : 'Hotkey cleared.', { nolog: true, force: true });
 		}
 	};
 
@@ -2285,7 +2285,7 @@
 						await migrateStringPackIds();
 
 						if (success) {
-							toastSuccess('Magane is now ready!', { timeout: 1000, force: true });
+							toastSuccess('Magane is now ready!', { force: true });
 						}
 						forceHideMagane = false;
 					}
@@ -2307,7 +2307,7 @@
 		let hrefUrl = '';
 
 		try {
-			toast('Exporting database\u2026');
+			toast('Exporting database\u2026', { timeout: 1000, force: true });
 			const database = {};
 			for (const key of allowedStorageKeys) {
 				const data = getFromLocalStorage(key);
@@ -2321,6 +2321,7 @@
 			element.href = hrefUrl;
 			element.download = `magane.database.${new Date().toISOString()}.json`;
 			element.click();
+			toastSuccess('Database exported!', { force: true });
 		} catch (error) {
 			console.error(error);
 			toastError('Unexpected error occurred. Check your console for details.');

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1254,6 +1254,9 @@
 			throw new Error('Invalid stickers count.');
 		}
 
+		// Standardize some values
+		e.animated = Boolean(e.animated);
+
 		const result = { pack: e };
 		if (isLocalPackID(id)) {
 			localPacks[id] = e;
@@ -1380,7 +1383,7 @@
 			name,
 			count,
 			id: mid,
-			animated: animated ? 1 : null,
+			animated,
 			files
 		});
 	};
@@ -1400,7 +1403,7 @@
 			name,
 			count,
 			id: mid,
-			animated: animated ? 1 : null,
+			animated,
 			files
 		});
 	};
@@ -1429,7 +1432,7 @@
 			name,
 			count,
 			id: mid,
-			animated: animated ? 1 : null,
+			animated,
 			files,
 			thumbs,
 			template,
@@ -1857,9 +1860,9 @@
 
 		// General chores
 		pack.count = pack.files.length;
-		// If all thumbs are missing, just empty the array
+		// If all thumbs are missing, just remove the prop
 		if (Array.isArray(pack.thumbs) && pack.thumbs.every(thumb => thumb === null)) {
-			pack.thumbs = [];
+			delete pack.thumbs;
 		}
 
 		return pack;
@@ -1904,7 +1907,7 @@
 			opts.id = `${match.result[2]}-${match.result[3]}`;
 			opts.homeUrl = url;
 
-			// API will now be always deteremined on-the-fly,
+			// API will now be always determined on-the-fly,
 			// to allow changing this in the future, if required,
 			// without breaking packs saved with any older methods.
 			const downloadUrl = `${match.result[1]}${match.result[2]}/api/album/${match.result[3]}`;
@@ -2043,7 +2046,7 @@
 				/* eslint-disable-next-line prefer-template */
 				contents.push('**URL Template:**\n\n```\n' + localPacks[id].template + '\n```');
 			}
-			if (localPacks[id].thumbs) {
+			if (Array.isArray(localPacks[id].thumbs) && localPacks[id].thumbs.length) {
 				/* eslint-disable-next-line prefer-template */
 				contents.push('**Thumbnails:**\n\n```\n' +
 					localPacks[id].thumbs.join('\n') +
@@ -2104,7 +2107,7 @@
 							name: props.title,
 							id: props.id,
 							count: props.len,
-							animated: props.hasAnimation || null
+							animated: Boolean(props.hasAnimation)
 						});
 					} else {
 						// LINE Stickers work with either its full URL or just its ID
@@ -2116,7 +2119,7 @@
 							name: props.title,
 							firstid: props.first,
 							count: props.len,
-							animated: props.hasAnimation
+							animated: Boolean(props.hasAnimation)
 						});
 					}
 					toastSuccess(`Added a new pack ${stored.pack.name}.`, { nolog: true, timeout: 1000, force: true });
@@ -2543,7 +2546,6 @@
 			element.href = hrefUrl;
 			element.download = `magane.database.${new Date().toISOString()}.json`;
 			element.click();
-			toastSuccess('Database exported!', { force: true });
 		} catch (error) {
 			console.error(error);
 			toastError('Unexpected error occurred. Check your console for details.');

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -68,17 +68,20 @@
 					const title = args[0];
 
 					// Re-map Markdown formatting to pure HTML
+					const html = args[1]
+						.split('\n\n')
+						.map(p => `<p>${p}</p>`)
+						.join('')
+						.replace(/\*\*(.*?)\*\*/gm, '<b>$1</b>')
+						.replace(/__(.*?)__/gm, '<u>$1</u>')
+						.replace(/```\n(.*?)\n```/gms, '<pre><code>$1</code></pre>')
+						.replace(/`(.*?)`/gm, '<code>$1</code>');
+
 					// Once again I'm reminded how whack it is to implant Svelte into React
 					const body = Modules.React.createElement('div', {
-						dangerouslySetInnerHTML: {
-							__html: args[1]
-								.replace(/\*\*(.*?)\*\*/gm, '<b>$1</b>')
-								.replace(/__(.*?)__/gm, '<u>$1</u>')
-								.replace(/```\n(.*?)\n```/gms, '<code>$1</code>')
-								.replace(/\n\n/gm, '<br>')
-						},
-						style: {
-							'user-select': 'text'
+						'class': 'magane-vencord-modal',
+						'dangerouslySetInnerHTML': {
+							__html: html
 						}
 					});
 
@@ -1864,7 +1867,7 @@
 
 		let remoteType = 'N/A';
 		if (typeof localPacks[id].remoteType === 'number') {
-			remoteType = `${localPacks[id].remoteType} – ${remotePackTypes[localPacks[id].remoteType] || 'N/A'}`;
+			remoteType = `\`${localPacks[id].remoteType}\` – ${remotePackTypes[localPacks[id].remoteType] || 'N/A'}`;
 		} else if (id.startsWith('startswith-')) {
 			remoteType = 'LINE';
 		} else if (id.startsWith('emojis-')) {
@@ -1872,26 +1875,45 @@
 		}
 
 		// Formatting is very particular, so we do this the old-fashioned way
-		/* eslint-disable prefer-template */
-		const content = '**ID:**\n\n' +
-			'```\n' + id + '\n```\n\n' +
-			'**Name:**\n\n' +
-			localPacks[id].name + '\n\n' +
-			'**Count:**\n\n' +
-			localPacks[id].count + '\n\n' +
-			'**Description:**\n\n' +
-			(localPacks[id].description || 'N/A') + '\n\n' +
-			'**Home URL:**\n\n' +
-			(localPacks[id].homeUrl || 'N/A') + '\n\n' +
-			'**Update URL:**\n\n' +
-			'```\n' + (localPacks[id].updateUrl || 'N/A') + '\n```\n\n' +
-			'**Remote Type:**\n\n' +
-			remoteType;
-		/* eslint-enable prefer-template */
+		const contents = [
+			/* eslint-disable-next-line prefer-template */
+			'**ID:**\n\n```\n' + id + '\n```',
+			`**Name:**\n\n${localPacks[id].name}`,
+			`**Count:**\n\n\`${localPacks[id].count}\``
+		];
+
+		if (localPacks[id].description) {
+			contents.push(`**Description:**\n\n${localPacks[id].description}`);
+		}
+
+		if (localPacks[id].homeUrl) {
+			contents.push(`**Home URL:**\n\n${localPacks[id].homeUrl}`);
+		}
+
+		if (localPacks[id].updateUrl) {
+			contents.push(`**Update URL:**\n\n${localPacks[id].updateUrl}`);
+		}
+
+		contents.push(`**Remote Type:**\n\n${remoteType}`);
+
+		if (typeof localPacks[id].remoteType === 'number') {
+			/* eslint-disable-next-line prefer-template */
+			contents.push('**Files:**\n\n```\n' +
+				localPacks[id].files.join('\n') +
+				'\n```');
+			if (localPacks[id].template) {
+				/* eslint-disable-next-line prefer-template */
+				contents.push('**URL Template:**\n\n```\n' + localPacks[id].template + '\n```');
+			}
+			if (localPacks[id].thumbsTemplate) {
+				/* eslint-disable-next-line prefer-template */
+				contents.push('**Thumbnail URL Template:**\n\n```\n' + localPacks[id].thumbsTemplate + '\n```');
+			}
+		}
 
 		Helper.Alerts.show(
 			localPacks[id].name,
-			content
+			contents.join('\n\n')
 		);
 	};
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -87,7 +87,8 @@
 
 					return VencordApi.Alerts.show(Object.assign({
 						title,
-						body
+						body,
+						className: 'magane-vencord-modal-container'
 					}, ...args.slice(2)));
 				}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -980,20 +980,18 @@
 
 				let filename = id;
 
-				if (pack.startsWith('custom-')) {
-					if (id.includes('#')) {
-						// Allow overriding filenames, for URLs that don't have extensions.
-						// e.g. https://example.com/path/to/image#custom_name.jpg
-						filename = id.substring(id.indexOf('#') + 1);
-					} else {
-						filename = id.substring(id.lastIndexOf('/') + 1).split('?')[0];
-					}
-				}
-
 				if (typeof pack === 'string') {
 					if (localPacks[pack].animated && (pack.startsWith('startswith-') || pack.startsWith('emojis-'))) {
 						filename = filename.replace(/\.png$/i, '.gif');
 						toastWarn('Animated stickers/emojis from LINE Store currently cannot be animated.');
+					} else if (pack.startsWith('custom-')) {
+						// Allow overriding filenames, for URLs that don't have extensions.
+						// e.g. https://example.com/path/to/image#custom_name.jpg
+						if (id.includes('#')) {
+							filename = id.substring(id.indexOf('#') + 1);
+						} else {
+							filename = id.substring(id.lastIndexOf('/') + 1).split('?')[0];
+						}
 					}
 				}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1261,7 +1261,9 @@
 		}
 
 		// Standardize some values
-		e.animated = Boolean(e.animated);
+		if ('animated' in e) {
+			e.animated = Boolean(e.animated);
+		}
 
 		const result = { pack: e };
 		if (isLocalPackID(id)) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -879,7 +879,7 @@
 				}
 
 				// Use wsrv.nl to downscale when desired
-				if (settings.stickerSize < 180) {
+				if (!settings.disableDownscale && settings.stickerSize < 180) {
 					const append = `&h=${settings.stickerSize}p&fit=inside&we`;
 					return `https://wsrv.nl/?url=${encodeURIComponent(url)}${append}`;
 				}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1904,6 +1904,12 @@
 				/* eslint-disable-next-line prefer-template */
 				contents.push('**URL Template:**\n\n```\n' + localPacks[id].template + '\n```');
 			}
+			if (localPacks[id].thumbs) {
+				/* eslint-disable-next-line prefer-template */
+				contents.push('**Thumbnails:**\n\n```\n' +
+					localPacks[id].thumbs.join('\n') +
+					'\n```');
+			}
 			if (localPacks[id].thumbsTemplate) {
 				/* eslint-disable-next-line prefer-template */
 				contents.push('**Thumbnail URL Template:**\n\n```\n' + localPacks[id].thumbsTemplate + '\n```');

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -846,8 +846,18 @@
 			} else {
 				url = id;
 			}
-			if (typeof localPacks[pack].template === 'string') {
-				url = localPacks[pack].template.replace(/%pack%/g, pack.replace('custom-', '')).replace(/%id%/g, url);
+
+			// If not sending, try thumbsTemplate if available, otherwise fallback to template
+			const template = sending
+				? localPacks[pack].template
+				: (localPacks[pack].thumbsTemplate || localPacks[pack].template);
+
+			if (typeof template === 'string') {
+				// Use anon functions so that they won't immediately be called if no matches
+				url = template
+					.replace(/%pack%/g, () => pack.replace('custom-', ''))
+					.replace(/%id%/g, url)
+					.replace(/%idencoded%/g, () => encodeURIComponent(url));
 			}
 		}
 		return url;
@@ -1245,8 +1255,8 @@
 	};
 
 	const appendCustomPack = (...args) => {
-		let { name, id, count, animated, template, files, thumbs } = parseFunctionArgs(args,
-			['name', 'id', 'count', 'animated', 'template', 'files', 'thumbs'], 5);
+		let { name, id, count, animated, template, files, thumbs, thumbsTemplate } = parseFunctionArgs(args,
+			['name', 'id', 'count', 'animated', 'template', 'files', 'thumbs', 'thumbsTemplate'], 5);
 
 		count = Math.max(Number(count), 0) || 0;
 		const mid = `custom-${id}`;
@@ -1271,7 +1281,8 @@
 			animated: animated ? 1 : null,
 			files,
 			thumbs,
-			template
+			template,
+			thumbsTemplate
 		});
 	};
 
@@ -1673,6 +1684,7 @@
 				pack.description = data.description ? String(data.description) : null;
 				pack.homeUrl = data.homeUrl ? String(data.homeUrl) : null;
 				pack.template = data.template ? String(data.template) : null;
+				pack.thumbsTemplate = data.thumbsTemplate ? String(data.thumbsTemplate) : null;
 
 				// Override update URL if required
 				if (data.updateUrl) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2512,7 +2512,7 @@
 				{ /each }
 			</div>
 
-			<div class="packs-toolbar { settings.useLeftToolbar ? 'has-scroll-y' : 'has-scroll-x' }">
+			<div class="packs-toolbar { settings.useLeftToolbar ? 'is-left' : 'is-bottom' }">
 				<div class="packs packs-controls">
 					<div class="packs-wrapper">
 						<div class="pack"
@@ -2537,7 +2537,7 @@
 					</div>
 				</div>
 
-				<div class="packs" style="">
+				<div class="packs { settings.useLeftToolbar ? 'has-scroll-y' : 'has-scroll-x' }" style="">
 					<div class="packs-wrapper">
 						{ #each subscribedPacks as pack, i }
 						<div class="pack"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1642,16 +1642,27 @@
 	};
 
 	const deleteLocalPack = id => {
-		try {
-			const _name = localPacks[id].name;
-			const deleted = deletePack(id);
-			if (deleted) {
-				toastSuccess(`Removed pack ${_name}.`, { nolog: true, force: true });
+		const name = localPacks[id].name;
+		Helper.Alerts.show(
+			`Purge Local Pack`,
+			`**${name}**\n\nAre you sure you want to do this?`, // Markdown, so we do double \n for new line
+			{
+				confirmText: 'Yes, purge it!',
+				cancelText: 'Cancel',
+				danger: true,
+				onConfirm: async () => {
+					try {
+						const deleted = deletePack(id);
+						if (deleted) {
+							toastSuccess(`Removed pack ${name}.`, { nolog: true, force: true });
+						}
+					} catch (error) {
+						console.error(error);
+						toastError(error.toString(), { nolog: true });
+					}
+				}
 			}
-		} catch (error) {
-			console.error(error);
-			toastError(error.toString(), { nolog: true });
-		}
+		);
 	};
 
 	const processRemotePack = async (data, opts) => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,6 +74,7 @@
 						.join('')
 						.replace(/\*\*(.*?)\*\*/gm, '<b>$1</b>')
 						.replace(/__(.*?)__/gm, '<u>$1</u>')
+						.replace(/\[(.*?)\]\((.*?)\)/gm, '<a href="$2" target="_blank">$1</a>')
 						.replace(/```\n(.*?)\n```/gms, '<pre><code>$1</code></pre>')
 						.replace(/`(.*?)`/gm, '<code>$1</code>');
 
@@ -1897,11 +1898,11 @@
 		}
 
 		if (localPacks[id].homeUrl) {
-			contents.push(`**Home URL:**\n\n${localPacks[id].homeUrl}`);
+			contents.push(`**Home URL:**\n\n[${localPacks[id].homeUrl}](${localPacks[id].homeUrl})`);
 		}
 
 		if (localPacks[id].updateUrl) {
-			contents.push(`**Update URL:**\n\n${localPacks[id].updateUrl}`);
+			contents.push(`**Update URL:**\n\n[${localPacks[id].updateUrl}](${localPacks[id].updateUrl})`);
 		}
 
 		contents.push(`**Remote Type:**\n\n${remoteType}`);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -863,8 +863,8 @@
 			}
 
 			// Don't include filename overrides in the final URL
-			if (url.includes('#')) {
-				url = url.substring(0, url.indexOf('#'));
+			if (url.includes(' ')) {
+				url = url.substring(0, url.indexOf(' '));
 			}
 
 			// If not sending, try thumbsTemplate if available, otherwise fallback to template
@@ -986,9 +986,9 @@
 						toastWarn('Animated stickers/emojis from LINE Store currently cannot be animated.');
 					} else if (pack.startsWith('custom-')) {
 						// Allow overriding filenames, for URLs that don't have extensions.
-						// e.g. https://example.com/path/to/image#custom_name.jpg
-						if (id.includes('#')) {
-							filename = id.substring(id.indexOf('#') + 1);
+						// e.g. https://example.com/path/to/image custom_name.jpg
+						if (id.includes(' ')) {
+							filename = id.substring(id.indexOf(' ') + 1);
 						} else {
 							filename = id.substring(id.lastIndexOf('/') + 1).split('?')[0];
 						}

--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -24,7 +24,7 @@
 
 <div bind:this={ element } id="maganeButton" class="channel-textarea-emoji channel-textarea-stickers"
 	class:active="{ active }"
-	title="Right-Click to reload Magane's built-in remote packs."
+	title="Right-click to reload Magane's built-in remote packs."
 	on:click="{ e => dispatch('click', e) }"
 	on:contextmenu|stopPropagation|preventDefault="{ e => dispatch('grabPacks', e) }">
 	<img class="channel-textarea-stickers-content" src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20width%3D%2224%22%20height%3D%2224%22%20preserveAspectRatio%3D%22xMidYMid%20meet%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M18.5%2011c-4.136%200-7.5%203.364-7.5%207.5c0%20.871.157%201.704.432%202.482l9.551-9.551A7.462%207.462%200%200%200%2018.5%2011z%22%20fill%3D%22%23b9bbbe%22%2F%3E%3Cpath%20d%3D%22M12%202C6.486%202%202%206.486%202%2012c0%204.583%203.158%208.585%207.563%209.69A9.431%209.431%200%200%201%209%2018.5C9%2013.262%2013.262%209%2018.5%209c1.12%200%202.191.205%203.19.563C20.585%205.158%2016.583%202%2012%202z%22%20fill%3D%22%23b9bbbe%22%2F%3E%3C%2Fsvg%3E" alt="Magane menu button">

--- a/src/bd-main.js
+++ b/src/bd-main.js
@@ -34,7 +34,7 @@ module.exports = class MaganeBD {
 		}
 		for (const id of Object.keys(global.MAGANE_STYLES)) {
 			const _id = `${this.constructor.name}-${id}`;
-			BdApi.clearCSS();
+			BdApi.clearCSS(_id);
 			this.log(`Cleared CSS with ID "${_id}".`);
 		}
 	}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -29,23 +29,24 @@ div#magane {
 	}
 
 	div.stickerWindow {
-		width: 600px;
+		width: 608px;
 		min-height: 200px;
 		position: fixed;
 		background: $backgroundPrimary;
-		max-height: 600px;
+		max-height: 608px;
 		transition: all 0.2s ease;
-		border-radius: 4px;
+		border-radius: $borderRadius;
 		box-shadow: var(--elevation-stroke, 0 0 0 1px #020203), var(--elevation-high, 0 8px 16px #000);
 
 		div.stickers {
 			height: 550px !important;
-			margin-bottom: 100px;
+			margin-bottom: 58px;
 			position: relative;
 
 			&.has-left-toolbar {
-				height: 600px !important;
-				margin-left: 50px;
+				height: 608px !important;
+				margin-left: 58px;
+				margin-bottom: 0;
 			}
 
 			h3.getStarted {
@@ -141,15 +142,17 @@ div#magane {
 		div.packs-toolbar {
 			position: absolute;
 			bottom: 0;
-			background: $backgroundSecondary;
 			display: flex;
+			background: $backgroundSecondary;
 
-			&.has-scroll-x {
+			&.is-bottom {
 				width: 100%;
-				height: 50px;
+				height: 58px;
+				border-bottom-right-radius: $borderRadius;
+				border-bottom-left-radius: $borderRadius;
 
 				div.packs {
-					flex: 1 0 auto;
+					flex: 1 1 auto;
 
 					&.packs-controls {
 						flex: 0 0 auto;
@@ -159,15 +162,21 @@ div#magane {
 						white-space: nowrap;
 						float: left;
 						width: 100%;
-						font-size: 0; /* quick hax to clear whitespace */
+						font-size: 0; /* clear whitespace */
+					}
+
+					div.pack {
+						margin: 9px 6px;
 					}
 				}
 			}
 
-			&.has-scroll-y {
-				width: 50px;
+			&.is-left {
+				width: 58px;
 				height: 100%;
 				flex-direction: column;
+				border-top-left-radius: $borderRadius;
+				border-bottom-left-radius: $borderRadius;
 
 				div.packs {
 					flex: 1 1 auto;
@@ -179,7 +188,11 @@ div#magane {
 					}
 
 					div.packs-wrapper {
-						font-size: 0; /* quick hax to clear whitespace */
+						font-size: 0; /* clear whitespace */
+					}
+
+					div.pack {
+						margin: 6px 9px;
 					}
 				}
 			}
@@ -188,7 +201,6 @@ div#magane {
 				display: inline-block;
 				height: 40px;
 				width: 40px;
-				margin: 5px;
 				cursor: pointer;
 				background-position: center;
 				background-size: contain;
@@ -249,7 +261,7 @@ div#magane {
 			box-sizing: border-box;
 			margin: 0 15px 10px;
 			padding: 5px 12px;
-			border-radius: 3px;
+			border-radius: $borderRadius;
 			border: 1px solid $backgroundPrimary;
 			background: $backgroundPrimary;
 			color: $textColor;
@@ -265,7 +277,7 @@ div#magane {
 			height: 36px;
 			box-sizing: border-box;
 			padding: 5px 12px;
-			border-radius: 3px;
+			border-radius: $borderRadius;
 			border: 1px solid $backgroundPrimary;
 			background: $backgroundPrimary;
 			color: $textColor;
@@ -283,14 +295,14 @@ div#magane {
 			background-color: rgba(10, 10, 10, 0.86);
 		}
 
-		.modal-content,
-		.modal-card {
+		.modal-content {
 			position: absolute;
 			width: 100%;
 			height: 100%;
 			left: 0;
 			top: 0;
 			background: $backgroundSecondary;
+			border-radius: $borderRadius;
 		}
 
 		.modal-content {
@@ -309,7 +321,7 @@ div#magane {
 					.tab {
 						color: $textColor;
 						display: inline-block;
-						border-radius: var(--radius-sm, 8px);
+						border-radius: $borderRadius;
 						font-weight: 600;
 						padding: 4px 12px;
 						transition: background-color .1s ease-in-out,color .1s ease-in-out;
@@ -328,7 +340,7 @@ div#magane {
 				}
 
 				div.tab-content {
-					height: calc(100% - 66px); /* .tabs height */
+					height: calc(100% - 64px); /* .tabs height */
 					width: 100%;
 					padding: 10px 0;
 					box-sizing: border-box;
@@ -568,10 +580,11 @@ div#magane {
 	.button {
 		align-items: center;
 		border: 1px solid transparent;
-		border-radius: 3px;
+		border-radius: $borderRadius;
 		box-shadow: none;
 		display: inline-flex;
 		font-size: 1rem;
+		font-weight: var(--font-weight-medium, 500);
 		padding: calc(0.375em - 1px) 0.75em;
 		position: relative;
 		vertical-align: top;
@@ -647,7 +660,8 @@ div#maganeButton {
 		align-items: center;
 		cursor: pointer;
 
-		&:hover, &.active {
+		&:hover,
+		&.active {
 			filter: brightness(1.35);
 		}
 	}
@@ -675,7 +689,7 @@ div#magane,
 div.magane-vencord-modal {
 	code {
 		font-family: $fontCode;
-		border-radius: 4px;
+		border-radius: var(--radius-xs, 4px);
 		margin: -.2em 0;
 		padding: 0 .2em;
 		box-sizing: border-box;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -599,20 +599,16 @@ div#magane {
 	}
 
 	.has-scroll-x {
-		overflow-x: auto;
+		overflow: auto hidden;
 		scrollbar-gutter: stable;
 	}
 
 	.has-scroll-y {
-		overflow-y: auto;
+		overflow: hidden auto;
 		scrollbar-gutter: stable;
 	}
 
 	::-webkit-scrollbar {
-		/* Let's make the scrollbars pretty */
-		width: 6px;
-		height: 6px;
-
 		&-track {
 			margin: 0;
 			background: transparent;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -78,6 +78,16 @@ div#magane {
 					.counts span {
 						padding: 0 0.5em;
 					}
+
+					&:has(+ .subtext) {
+						margin-bottom: 0;
+					}
+
+					&.subtext {
+						color: var(--text-muted, #94959c);
+						font-size: 13px;
+						margin-top: 0;
+					}
 				}
 
 				div.sticker {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -295,26 +295,28 @@ div#magane {
 				flex-direction: column;
 
 				.tabs {
+					padding: 16px;
 					width: 100%;
+					box-sizing: border-box;
 					text-align: center;
 
 					.tab {
 						color: $textColor;
 						display: inline-block;
-						border: none;
-						border-top: 0px transparent;
-						border-left: 0px transparent;
-						border-right: 0px transparent;
-						border-width: 1px;
-						border-style: solid;
-						border-bottom-color: $textColor;
-						padding: 20px;
+						border-radius: var(--radius-sm, 8px);
+						font-weight: 600;
+						padding: 4px 12px;
+						transition: background-color .1s ease-in-out,color .1s ease-in-out;
 						cursor: pointer;
 
-						&:hover,
+						&:hover {
+							color: var(--interactive-hover, #fbfbfb);
+							background: var(--button-secondary-background-hover, #97979f33);
+						}
+
 						&.is-active {
-							border-bottom-color: $hoverColor;
-							color: $hoverColor;
+							color: var(--button-secondary-text, #ebebed);
+							background: var(--button-secondary-background, #97979f1f);
 						}
 					}
 				}
@@ -519,8 +521,8 @@ div#magane {
 			vertical-align: top;
 			background: none;
 			position: absolute;
-			right: 20px;
-			top: 20px;
+			right: 16px;
+			top: 16px;
 			height: 32px;
 			max-height: 32px;
 			max-width: 32px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -693,6 +693,12 @@ div.magane-vencord-modal {
 	}
 }
 
+div.magane-vencord-modal-container {
+	width: auto;
+	min-width: 442px;
+	max-width: 663px;
+}
+
 /* Visually hide Magane button in certain scenarios */
 
 div[class^="submitContainer_"] div#maganeButton { /* create thread */

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,11 +1,15 @@
 /** Magane: main.scss **/
 
+$backgroundPrimary: var(--background-surface-high, #242429);
+$backgroundSecondary: var(--background-base-lower, #1a1a1e);
+$textColor: var(--header-secondary, #efeff0);
+
+$scrollbarColor: rgb(105, 96, 128);
+
+$fontDisplay: var(--font-display, "gg sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif);
+$fontCode: var(--font-code, "gg mono", "Source Code Pro", Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace);
+
 div#magane {
-	$backgroundPrimary: var(--background-base-low, #202024);
-	$backgroundSecondary: var(--background-base-lower, #1a1a1e);
-	$textColor: var(--header-secondary, #efeff0);
-	$hoverColor: var(--interactive-active, #fbfbfb);
-	$scrollbarColor: rgb(105, 96, 128);
 	display: flex;
 	flex-direction: row;
 	height: 44px;
@@ -13,7 +17,7 @@ div#magane {
 	z-index: 1001;
 
 	button, input, select, label, span, p, a, li, ul, div, textarea {
-		font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+		font-family: $fontDisplay;
 		color: $textColor;
 		font-weight: 400;
 		line-height: 1.5;
@@ -637,15 +641,6 @@ div#magane {
 			}
 		}
 	}
-
-	code {
-		box-sizing: border-box;
-		padding: 2px 6px;
-		border-radius: 3px;
-		border: 1px solid $backgroundPrimary;
-		background: $backgroundPrimary;
-		color: $textColor;
-	}
 }
 
 div#maganeButton {
@@ -665,6 +660,36 @@ div#maganeButton {
 		padding: 4px;
 		margin-left: 2px;
 		margin-right: 2px;
+	}
+}
+
+div.magane-vencord-modal {
+	color: $textColor;
+	user-select: text;
+
+	p {
+		margin: 0;
+		margin-bottom: 8px;
+	}
+}
+
+div#magane,
+div.magane-vencord-modal {
+	code {
+		font-family: $fontCode;
+		border-radius: 4px;
+		margin: -.2em 0;
+		padding: 0 .2em;
+		box-sizing: border-box;
+		border: 1px solid var(--border-normal, #97979f33);
+		background: var(--background-code, #5865f214);
+		color: $textColor;
+	}
+
+	pre code {
+		display: block;
+		padding: .5em;
+		overflow-x: auto;
 	}
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,7 +4,7 @@ $backgroundPrimary: var(--background-surface-high, #242429);
 $backgroundSecondary: var(--background-base-lower, #1a1a1e);
 $textColor: var(--header-secondary, #efeff0);
 
-$scrollbarColor: rgb(105, 96, 128);
+$borderRadius: var(--radius-sm, 8px);
 
 $fontDisplay: var(--font-display, "gg sans", "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif);
 $fontCode: var(--font-code, "gg mono", "Source Code Pro", Consolas, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", Monaco, "Courier New", Courier, monospace);
@@ -15,6 +15,8 @@ div#magane {
 	height: 44px;
 	position: absolute;
 	z-index: 1001;
+	scrollbar-width: auto !important;
+	scrollbar-color: auto !important;
 
 	button, input, select, label, span, p, a, li, ul, div, textarea {
 		font-family: $fontDisplay;
@@ -606,39 +608,35 @@ div#magane {
 
 	.has-scroll-x {
 		overflow: auto hidden;
-		scrollbar-gutter: stable;
 	}
 
 	.has-scroll-y {
 		overflow: hidden auto;
-		scrollbar-gutter: stable;
 	}
 
 	::-webkit-scrollbar {
-		&-track {
-			margin: 0;
-			background: transparent;
-			border-radius: 5px;
+		height: 8px !important;
+		width: 8px !important;
 
-			&-piece {
-				border: 0 solid transparent;
-				background: transparent;
-				margin: 0;
-			}
+		&-corner {
+			background-color: transparent;
+		}
+
+		&-track {
+			background-color: var(--scrollbar-auto-track, transparent);
+			margin: $borderRadius 0 !important;
 		}
 
 		&-thumb {
-			background: rgba($scrollbarColor, 0.5);
-			border: 0 solid transparent;
-			border-radius: 5px;
+			background-color: var(--scrollbar-auto-thumb, #666771);
+			min-height: 40px;
+		}
 
-			&:hover {
-				background: rgba($scrollbarColor, 0.75);
-			}
-
-			&:active {
-				background: rgba($scrollbarColor, 1);
-			}
+		&-track,
+		&-thumb {
+			background-clip: padding-box;
+			border: 0 solid transparent !important;
+			border-radius: $borderRadius;
 		}
 	}
 }

--- a/src/vencord-native.ts
+++ b/src/vencord-native.ts
@@ -11,3 +11,37 @@ CspPolicies['wsrv.nl'] = ImageSrc;
 
 // If you need to import packs from third-party Chibisafe-based hosts, add the domains here.
 // CspPolicies['example.com'] = ImageSrc;
+
+export async function fetchNative(_, ...args) {
+	return fetch(...args);
+}
+
+export async function fetchNativeJson(_, ...args) {
+	const response = await fetch(...args);
+	let data;
+	if (response.status !== 204) {
+		data = await response.json();
+	}
+	return {
+		response: {
+			status: response.status,
+			statusText: response.statusText
+		},
+		data
+	};
+}
+
+export async function fetchNativeArrayBuffer(_, ...args) {
+	const response = await fetch(...args);
+	let data;
+	if (response.status !== 204) {
+		data = await response.arrayBuffer();
+	}
+	return {
+		response: {
+			status: response.status,
+			statusText: response.statusText
+		},
+		data
+	};
+}


### PR DESCRIPTION
Notable changes:
- Fixes to scrollbar styling, due to [this](https://developer.chrome.com/docs/css-ui/scrollbar-styling) being the new standard which caused faults with our old styling.
- **Custom packs:** Support `thumbsTemplate` option.  
Several hosts support image processing keywords that can be used to auto-resize the images to save bandwidth.  
Sample: https://gist.github.com/BobbyWibowo/2a73ec8fa2197f156a8f8a81a2ae0aa0?permalink_comment_id=5648349#gistcomment-5648349
- **Custom packs:** Support filename overrides.
Some hosts may omit extension name from the final URL, or it has some other things after the filename.  
Instead of futilely trying to determine via header, or more perverse RegEx, just allow users to override when needed.  
e.g., Assuming the URL has a whitespace, `"https://static.wikia.nocookie.net/gensin-impact/images/6/6f/Icon_Emoji_Paimon%27s_Paintings_Kiehl%27s_1.png/revision/latest 1.png"`, anything after the first found whitespace will be assumed to be the filename (`1.png` in this example).  
Sample: https://gist.github.com/BobbyWibowo/2a73ec8fa2197f156a8f8a81a2ae0aa0?permalink_comment_id=5646855#gistcomment-5646855
- Improve packs info modal.  
  <details>
  <summary>Show more fields for custom packs</summary>
  
  ![image](https://i.imgur.com/dVeKKSZ.png)
  </details>
  <details>
  <summary>Omit empty/missing fields for other imported packs</summary>
  
  ![image](https://i.imgur.com/euiAhbN.png)
  LINE Store packs now also store their origin URLs.
  </details>
- Hoist controls buttons in left/bottom packs toolbar.
  <details>
  <summary>Screenshot</summary>
  
  ![image](https://i.imgur.com/amnJw4v.png)
  </details>
- Support setting max height for stickers.  
  Only enabled if user doesn't disable `wsrv.nl` downscaling.  
  Will also affect Magane's built-in packs.  
  <details>
  <summary>Screenshot</summary>
  
  ![image](https://i.imgur.com/IDuS89N.png)
  Vencord-related message will not appear in the BetterDiscord-edition.
  </details>
- **Custom packs:** Support more keywords for `template` (and `thumbsTemplate`):
  `%idencoded%` for the URL, but encoded, to better support using `wsrv.nl` and similar services for custom packs.  
  `%size%` for user-configured stickers max height, to better support dynamically resizing custom packs.  
  Linked samples in previous sections actually already used them.

**Vencord-only notable changes:**
- Use native `fetch()` to allow bypassing CORS.
- In-app conversion of APNG to GIF, which means complete support for animated LINE stickers/emojis.  
  Vencord has the necessary libraries shipped in, because one of their built-in plugins (FakeNitro) will forever need them to convert Discord's own APNG stickers. The libraries are accessible by other plugins, so it's free real estate.
  This is why I need this: https://github.com/Pitu/Magane-server/pull/20
- Right-click animated stickers to replay their thumbnails.  
  Since we will render the APNGs as-is for thumbnails, they are subject to LINE's 1-time playback setting.
  <details>
  <summary>Clip</summary>
  
  https://github.com/user-attachments/assets/ae8578f4-fb6f-4f6f-86e8-a036cb3e2998
  </details>
  The converted stickers that will be sent will have infinite loop.