### PR TITLE
fix: oversight caused built-in animated packs to error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magane",
-  "version": "3.2.24",
+  "version": "3.2.25",
   "description": "A lie about a lie... It turns inside-out on itself.",
   "author": "Pitu <heyitspitu@gmail.com>",
   "license": "MIT",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2652,7 +2652,7 @@
 				{ #each subscribedPacks as pack, i }
 				<div class="pack">
 					<span id="p{pack.id}">{ pack.name }{ @html formatStickersCount(pack.files.length) }</span>
-					{ #if pack.animated && mountType === MountType.VENCORD && (pack.id.startsWith('startswith-') || pack.id.startsWith('emojis-')) }
+					{ #if mountType === MountType.VENCORD && typeof pack.id === 'string' && pack.animated && (pack.id.startsWith('startswith-') || pack.id.startsWith('emojis-')) }
 					<span class="subtext">Right-click the sticker to replay its animation.</span>
 					{ /if }
 


### PR DESCRIPTION
basically just missing `typeof pack.id === 'string'` because i forgot that built-in packs have their IDs as numbers, but i was only checking against animated imported/custom packs